### PR TITLE
docs: CLAUDE.md Task Rules repo별 분리 및 스킬 중복 제거

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,40 +52,37 @@ When you need context about past work, technical decisions, or known issues, **r
 
 ## Task Rules
 
-Follow this order when receiving coding tasks:
+### client / server (Issue-driven)
 
-1. **Check Issue** — verify with `gh issue list`, create with user approval if missing
-2. **Run `/dev-build`** — create worktree → code → create PR
-3. **Run `/dev-log`** — record in `docs/{area}/` when technical research/decisions occur
+`/dev-pipeline`이 전체 사이클을 관리: build → review → resolve → merge.
+브랜치/커밋/PR/워크트리 규칙은 스킬 내장.
 
-## Git Workflow
+### root repo (사용자 지시 기반)
 
-main + feature branches only. Never push directly to main.
-**All work must go through a worktree** (`.workspace/worktrees/`) — never commit directly on `main`.
-
-```
-Branch: {feat|fix|docs|refactor}/issue-{N}-{description}
-Commit: {type}: {description} (#{N})
-PR:     Include Closes #{N}
-```
+사용자가 지시한 작업을 수행한다. 경중에 따라 Issue를 작성할 수도 있다.
+작업 완료 후 `/dev-log`로 `docs/workspace/`에 기록.
 
 ```
-Check Issue → create worktree (.workspace/worktrees/) → code → push → PR → review → user approval → merge → cleanup worktree
+worktree 생성 → 작업 → 사용자 선택 (로컬 merge 또는 PR) → /dev-log
 ```
 
-## Multi-Agent
+- Worktree: `.workspace/worktrees/{type}-{description}`
+- Branch: `{type}/{description}`
+- Commit: `{type}: {description}`
 
-- 1 agent = 1 Issue, worktree isolation required
-- Never work on Issues that modify the same files simultaneously
-- Technical decisions: draft in `docs/{area}/decisions/` → proceed after user approval
+## Git Rules
+
+- main + feature branches only. Never push directly to main.
+- All work must go through a worktree (`.workspace/worktrees/`).
+- Multi-agent: 1 agent = 1 task, worktree isolation. 같은 파일을 동시에 수정하지 않는다.
 
 ## Skills
 
 | Skill | Purpose |
 |-------|---------|
-| `/dev-pipeline` | Auto orchestration (build → review → resolve → merge) |
-| `/dev-build` | Issue → Worktree → Code → PR workflow |
+| `/dev-pipeline` | Full cycle: build → review → resolve → merge (client/server) |
+| `/dev-build` | Issue → Worktree → Code → PR (client/server) |
 | `/dev-log` | progress / findings / decisions records |
 | `/dev-review` | PR code review |
 | `/dev-resolve` | Address review comments |
-| `/frontend-design` | Use for UI design tasks |
+| `/frontend-design` | UI design tasks |


### PR DESCRIPTION
## Summary

- Task Rules를 client/server(Issue-driven)와 root repo(사용자 지시 기반)로 분리
- 스킬(`/dev-build`, `/dev-pipeline`)이 이미 내장한 브랜치/커밋/PR 네이밍 규칙을 CLAUDE.md에서 제거
- root repo 워크플로우 추가: worktree 네이밍, 로컬 merge 또는 PR 선택 가능
- Git Workflow → Git Rules로 슬림화, Multi-Agent 규칙 통합

## Test plan

- client/server 작업 시 `/dev-pipeline` 스킬이 정상 동작하는지 확인
- root repo 작업 시 새 워크플로우 규칙이 적용되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)