### PR TITLE
fix: agent-tracker 다중 에이전트 트래킹 오류 및 대시보드 개선 (#12)

### DIFF
--- a/scripts/agent-tracker.sh
+++ b/scripts/agent-tracker.sh
@@ -46,7 +46,7 @@ while getopts ":s:i:h" opt; do
     h)
       printf 'Usage: %s [-s SESSION] [-i INTERVAL]\n' "$(basename "$0")"
       printf '  -s SESSION   tmux session name (default: lab)\n'
-      printf '  -i INTERVAL  refresh interval in seconds (default: 2)\n'
+      printf '  -i INTERVAL  refresh interval in seconds (default: 1)\n'
       exit 0 ;;
     \?) printf 'Unknown option: -%s\n' "$OPTARG"; exit 1 ;;
   esac


### PR DESCRIPTION
## Summary
Closes #12

- **Transcript 매핑 수정**: `find_claude_transcript()` 교체 — TTY→PID→`/proc/fd` 스캔으로 동일 CWD의 여러 Claude 인스턴스가 각자 고유 transcript 참조 (Task/Token 공유 버그 해결)
- **CJK display width**: `display_width()`(wc -L) + binary search `trunc()`으로 한글 등 2칸 문자 포함 task 표시 시 컬럼 정렬 유지
- **모델명 transcript 추출**: pane 스크래핑 제거 → `message.model` 필드에서 추출 (`claude-opus-4-6` → `Opus 4.6`). model+token+task 단일 jq 호출로 통합 (~4× 성능)
- **스피너 감지 수정**: Claude Code 스피너 `✢|✶|✽` 추가 (기존 `✻`만 → 80% miss 해소)
- **반응형 레이아웃**: TOKENS min/grow + TASK fill, refresh 1초

## Test plan
- 같은 CWD에서 Claude 2개+ 실행 시 각기 다른 Task/Token 표시 확인
- 한글 task 입력 시 ║ 테두리 정렬 유지 확인
- 150줄+ 대화 후 Engine에 구체적 모델명(Opus 4.6 등) 표시 확인
- Claude 작업 중 Status ● work 즉시 반영 확인 (idle 오탐 없음)
- 1초 갱신, 5+ pane에서 깨지지 않음 확인
- 터미널 너비 변경 시 TASK 컬럼 반응형 확인
