### PR TITLE
fix: agent-tracker Task/Activity 영숫자 누락 - gsub regex 수정 (#34)

### DIFF
--- a/tools/agent-tracker/hooks/on-status.sh
+++ b/tools/agent-tracker/hooks/on-status.sh
@@ -52,7 +52,7 @@ case "$event" in
     task=$(printf '%s' "$input" | jq -r '
       .prompt // "" |
       gsub("\n"; " ") | gsub("  +"; " ") |
-      gsub("[\\u0000-\\u001f\\u007f]"; "") |
+      gsub("[[:cntrl:]]"; "") |
       ltrimstr(" ") | rtrimstr(" ") |
       if length > 200 then .[:200] + "..." else . end
     ')
@@ -97,7 +97,7 @@ case "$event" in
         end |
         tostring |
         gsub("\n"; " ") | gsub("  +"; " ") |
-        gsub("[\\u0000-\\u001f\\u007f]"; "") |
+        gsub("[[:cntrl:]]"; "") |
         ltrimstr(" ") | rtrimstr(" ")
       ')
       if [[ -n "$key_arg" ]]; then


### PR DESCRIPTION
## Summary

Closes #34

`on-status.sh`의 jq gsub 패턴 `gsub("[\\u0000-\\u001f\\u007f]"; "")` 에서 jq 1.7 Oniguruma regex 엔진이 `\\u`를 유니코드 이스케이프로 인식하지 못해 `0-u` 범위(ASCII 0x30-0x75)가 매칭됨. 숫자(0-9), 영문 대문자(A-Z), 소문자 a-u가 모두 제거되어 Task/Activity 컬럼에 빈칸만 표시되던 버그.

`[[:cntrl:]]` (POSIX control character class)로 교체하여 제어 문자만 정확히 제거.

## Changes

- `tools/agent-tracker/hooks/on-status.sh` line 55: UserPromptSubmit task 필터링
- `tools/agent-tracker/hooks/on-status.sh` line 100: PreToolUse key_arg 필터링

## Check plan

- [ ] `printf '"Hello World 123"' | jq -r 'gsub("[[:cntrl:]]"; "")'` 가 `Hello World 123` 출력
- [ ] agent-tracker 대시보드에서 영숫자 포함 task 정상 표시
- [ ] 제어 문자 제거 동작 유지
