### PR TITLE
refactor: Issue 관리 체계 개선 (#37)

### DIFF
--- a/.agents/skills/dev-issue/SKILL.md
+++ b/.agents/skills/dev-issue/SKILL.md
@@ -38,6 +38,25 @@ Use argument if provided. Otherwise ask the user:
 2. Select the matching template (bug / feature / refactor) based on content.
 3. Compose the Issue body following the template's field structure.
 
+#### Title rules
+
+- **No type prefix** in Issue titles. Do not prepend `feat:`, `fix:`, `refactor:`, etc.
+- Type is conveyed through GitHub labels, not the title.
+- Good: `Admin 댓글 관리 페이지`
+- Bad: `feat: Admin 댓글 관리 페이지`
+
+#### Labels
+
+Labels are GitHub labels defined in each repo's `.github/labels.json`.
+
+| Category | Labels |
+|----------|--------|
+| Type | `feat`, `bug`, `refactor`, `docs`, `test`, `chore` |
+| Priority | `priority:0` ~ `priority:4` |
+| Status | `fixed`, `duplicate`, `attention`, `question` |
+
+Always apply **type + priority** labels when creating an Issue.
+
 ### 4. Create Issues
 
 1. Check existing: `gh issue list --state open --repo {repo} --json number,title,labels`

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -62,14 +62,6 @@ body:
       description: 계획된 수정 방법을 설명해 주세요.
       placeholder: "예: Optional chaining 적용하여 null 안전성 확보"
   - type: textarea
-    id: done
-    attributes:
-      label: Definition of Done
-      description: 버그가 해결되었음을 확인할 수 있는 조건을 작성해 주세요.
-      placeholder: |
-        - [ ] 재현 시나리오에서 문제 미발생
-        - [ ] 관련 테스트 추가 및 통과
-  - type: textarea
     id: dependencies
     attributes:
       label: Dependencies

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -61,17 +61,6 @@ body:
       description: 추가 라이브러리가 필요한 경우 작성해 주세요.
       placeholder: "예: react-markdown, zod 등"
   - type: textarea
-    id: done
-    attributes:
-      label: Definition of Done
-      description: 체크리스트 형태로 완료 조건을 작성해 주세요.
-      placeholder: |
-        - [ ] 기능 동작 확인
-        - [ ] 관련 테스트 추가 및 통과
-        - [ ] 코드 리뷰 완료
-    validations:
-      required: true
-  - type: textarea
     id: dependencies
     attributes:
       label: Dependencies

--- a/.github/ISSUE_TEMPLATE/refactor.yml
+++ b/.github/ISSUE_TEMPLATE/refactor.yml
@@ -46,17 +46,6 @@ body:
     validations:
       required: true
   - type: textarea
-    id: done
-    attributes:
-      label: Definition of Done
-      description: 리팩토링 완료를 확인할 수 있는 조건을 작성해 주세요.
-      placeholder: |
-        - [ ] 기존 기능 정상 동작 확인
-        - [ ] 관련 테스트 통과
-        - [ ] 코드 리뷰 완료
-    validations:
-      required: true
-  - type: textarea
     id: dependencies
     attributes:
       label: Dependencies

--- a/.github/labels.json
+++ b/.github/labels.json
@@ -40,6 +40,11 @@
     "description": "Testing only, not for production"
   },
   {
+    "name": "chore",
+    "color": "#795548",
+    "description": "Build, config, or maintenance tasks"
+  },
+  {
     "name": "refactor",
     "color": "#000000",
     "description": "Code cleanup, refactoring, or renaming"


### PR DESCRIPTION
## Summary
Closes #37

- Issue 제목에서 type prefix 제거, GitHub label로 통일
- 3개 템플릿 (bug, feature, refactor) DoD 필드 제거
- labels.json에 `chore` label 추가

## Changes
- **SKILL.md**: 제목 규칙 (no prefix) + label 카테고리 테이블 추가
- **bug.yml**: Definition of Done 필드 제거
- **feature.yml**: Definition of Done 필드 제거
- **refactor.yml**: Definition of Done 필드 제거
- **labels.json**: `chore` label 추가

## Check plan
- GitHub Issue 템플릿에서 DoD 필드가 사라졌는지 확인
- labels.json에 chore 항목 존재 확인
- SKILL.md 제목 규칙 및 label 테이블 확인
