### PR TITLE
refactor: PR 템플릿 통일 - Check plan 제거 (#36)

### DIFF
--- a/.agents/skills/dev-build/SKILL.md
+++ b/.agents/skills/dev-build/SKILL.md
@@ -51,14 +51,14 @@ Run `/dev-log` before pushing.
 git push -u origin {type}/issue-{N}-{desc}
 ```
 
-Write body to `.workspace/messages/pr-{N}-body.md`, then:
+Read `{area}/.github/PULL_REQUEST_TEMPLATE.md` for the PR body structure. Write body to `.workspace/messages/pr-{N}-body.md`, then:
 
 ```bash
 gh pr create --title "{type}: description (#{N})" --body-file .workspace/messages/pr-{N}-body.md
 rm .workspace/messages/pr-{N}-body.md
 ```
 
-→ [pr-template.md](references/pr-template.md)
+→ [pr-template.md](references/pr-template.md) (title format, `gh pr create` usage)
 
 ### 5. Next step
 

--- a/.agents/skills/dev-build/references/pr-template.md
+++ b/.agents/skills/dev-build/references/pr-template.md
@@ -1,30 +1,6 @@
 # PR Template
 
-## Body
-
-```markdown
-## Summary
-Closes #{N}
-
-- Change 1
-- Change 2
-
-## Changes
-- **file1**: Description
-- **file2**: Description
-
-## Check plan
-- Verification step 1
-- Verification step 2
-
-## Screenshots
-(Attach if UI changes)
-```
-
-## Required
-1. `Closes #{N}` — Auto-closes the Issue
-2. **Summary** — 1-3 bullet points
-3. **Check plan** — Post-merge verification steps (plain list, no checkboxes)
+Use the area's `.github/PULL_REQUEST_TEMPLATE.md` as the base. Fill in each section; delete sections that don't apply.
 
 ## PR Title
 ```
@@ -33,7 +9,7 @@ Closes #{N}
 
 ## gh pr create
 
-**`--body-file` required** — inline `--body` causes shell escape conflicts with markdown backticks.
+**`--body-file` required** - inline `--body` causes shell escape conflicts with markdown backticks.
 
 ```bash
 mkdir -p .workspace/messages
@@ -41,8 +17,11 @@ cat > .workspace/messages/pr-{N}-body.md <<'PREOF'
 ## Summary
 Closes #{N}
 - Change description
-## Check plan
-- Verification step
+
+## Changes
+| File | Change |
+|------|--------|
+| `file` | description |
 PREOF
 
 gh pr create \

--- a/.agents/skills/dev-pipeline/SKILL.md
+++ b/.agents/skills/dev-pipeline/SKILL.md
@@ -123,13 +123,9 @@ rc=$?
 
 Handle `rc` same as Step 3. When new commits appear: kill pane → show diff (`gh pr diff {PR#}`). `skipReview: true` → Step 6. `skipReview: false` → ask user: "Re-review" (→ Step 2) | "Merge as-is" (→ Step 6) | "Manual edit" (→ user edits, then Step 2).
 
-### 5. No critical — user decision
+### 5. No critical - user decision
 
-Show review summary. Show check plan:
-
-```bash
-gh pr view {PR#} --json body --jq '.body' | grep -A999 '## Check plan' | tail -n +2 || true
-```
+Show review summary.
 
 Ask user: **"Merge"** → Step 6 | **"Fix & Re-review"** → Step 4a | **"Fix & Merge"** → Step 4a with `skipReview: true`.
 

--- a/.agents/skills/dev-review/SKILL.md
+++ b/.agents/skills/dev-review/SKILL.md
@@ -23,10 +23,6 @@ Read diff + surrounding context. Check `{area}/CLAUDE.md` compliance.
 
 Focus: Security (OWASP Top 10), type safety, edge cases, error handling, performance (N+1), conventions.
 
-### 2.5. Check plan review
-
-Read Check plan items from PR body. For each item: note if covered by diff or requires post-merge verification.
-
 ### 3. Classify & submit
 
 Classify findings by severity and submit. → [review-template.md](references/review-template.md)


### PR DESCRIPTION
## Summary
Closes #36

- PR body에서 Check plan 섹션 삭제 (root repo 범위)
- dev-build가 area의 `.github/PULL_REQUEST_TEMPLATE.md`를 직접 참조하도록 변경
- dev-review, dev-pipeline에서 Check plan 관련 로직 제거

## Changes
| File | Change |
|------|--------|
| `dev-build/references/pr-template.md` | Check plan 섹션 삭제, `.github/PULL_REQUEST_TEMPLATE.md` 참조로 전환 |
| `dev-build/SKILL.md` | PR 생성 시 area의 `.github/PULL_REQUEST_TEMPLATE.md` 읽도록 지시 추가 |
| `dev-review/SKILL.md` | Step 2.5 (Check plan review) 제거 |
| `dev-pipeline/SKILL.md` | Step 5에서 Check plan grep 코드 제거 |

## Notes
client/server `.github/PULL_REQUEST_TEMPLATE.md` 통일은 별도 작업 필요
