### PR TITLE
fix: prevent orphan pane proliferation in pipeline helpers

### DIFF
--- a/.agents/skills/dev-pipeline/references/pane-lifecycle.md
+++ b/.agents/skills/dev-pipeline/references/pane-lifecycle.md
@@ -8,10 +8,49 @@
 | 1 | `TIMEOUT` | Polling expired |
 | 2 | `PANE_DEAD` | Pane process died |
 | 3 | `PATH_INVALID` | Working directory not found |
-| 4 | `RETRY_FAILED` | Auto-retry also failed |
 
 ## Key behaviors
 
-- `pipeline_open_pane_verified()`: validates dir → opens pane → 3s startup check → auto-retries once with path re-resolution on failure
+- `pipeline_open_pane_verified()`: validates dir → opens pane → 3s startup check. Single attempt only (no internal retry). On failure, captures dead pane output via `remain-on-exit` for diagnosis, then cleans up.
 - `pipeline_poll_review()` / `pipeline_poll_commits()`: checks API first (catches normal exit), then pane health. Prevents false PANE_DEAD when task completed normally.
-- Auto-retry policy: max 1 retry per pane-open or polling cycle. On retry failure → report to user.
+- No auto-retry at the helper level. Orchestrator decides whether to retry, report, or escalate.
+
+## Orchestrator protocol for opening panes
+
+The orchestrator must follow this 3-layer protocol to prevent orphan pane proliferation:
+
+### Layer 1: Pre-defense (before calling `pipeline_open_pane_verified`)
+
+```bash
+# Kill any previous pane recorded in state
+pipeline_kill_state_pane "$ISSUE" "$AREA" "reviewPane"
+
+# Snapshot current panes for orphan detection
+pipeline_pane_snapshot > /tmp/panes_before_${ISSUE}.txt
+```
+
+### Layer 2: Execution (single call, file-based capture)
+
+```bash
+# Always redirect to file - never rely on bash variable capture
+PANE_OUT="/tmp/pipeline-pane-${ISSUE}-${AREA}.txt"
+pipeline_open_pane_verified "$WORKDIR" "$PROMPT" "$AGENT" \
+  "$ORCHESTRATOR_PANE" "$ISSUE" "$AREA" > "$PANE_OUT" 2>/tmp/pipeline-pane-err.txt
+RC=$?
+PANE_ID=$(cat "$PANE_OUT")
+
+# NEVER retry with different bash syntax. One call only.
+```
+
+### Layer 3: Post-diagnosis (on failure only)
+
+```bash
+if [ $RC -ne 0 ]; then
+  # Clean up orphans created during the failed attempt
+  pipeline_pane_snapshot > /tmp/panes_after_${ISSUE}.txt
+  pipeline_pane_orphan_cleanup /tmp/panes_before_${ISSUE}.txt /tmp/panes_after_${ISSUE}.txt
+
+  # Report diagnosis (stderr from the function contains dead pane output)
+  # Escalate to user - do not auto-retry
+fi
+```

--- a/.agents/skills/dev-pipeline/scripts/pipeline-helpers.sh
+++ b/.agents/skills/dev-pipeline/scripts/pipeline-helpers.sh
@@ -104,6 +104,47 @@ pipeline_pane_alive() {
   tmux list-panes -a -F '#{pane_id}' 2>/dev/null | grep -qx "$pane_id"
 }
 
+pipeline_pane_snapshot() {
+  # Usage: pipeline_pane_snapshot
+  # Outputs sorted list of all current tmux pane IDs.
+  # Use before/after pane creation to detect orphans.
+  tmux list-panes -a -F '#{pane_id}' 2>/dev/null | sort
+}
+
+pipeline_pane_orphan_cleanup() {
+  # Usage: pipeline_pane_orphan_cleanup <before_file> <after_file>
+  # Kills panes that appeared between two snapshots (orphans from failed opens).
+  # before_file/after_file: files containing sorted pane ID lists.
+  local before=$1
+  local after=$2
+  local orphans
+  orphans=$(comm -13 "$before" "$after")
+  local count=0
+  for p in $orphans; do
+    tmux kill-pane -t "$p" 2>/dev/null
+    count=$((count + 1))
+  done
+  if [ "$count" -gt 0 ]; then
+    >&2 echo "[pipeline] Cleaned up $count orphan pane(s): $orphans"
+  fi
+}
+
+pipeline_kill_state_pane() {
+  # Usage: pipeline_kill_state_pane <issue> <area> <field>
+  # Kills a pane recorded in state (e.g. reviewPane, resolvePane).
+  local issue=$1
+  local area=$2
+  local field=$3
+  if ! pipeline_state_exists "$issue" "$area"; then
+    return
+  fi
+  local pane_id
+  pane_id=$(pipeline_state_read "$issue" "$area" | jq -r ".${field} // empty")
+  if [ -n "$pane_id" ]; then
+    pipeline_kill_pane "$pane_id"
+  fi
+}
+
 pipeline_resolve_worktree_path() {
   # Usage: pipeline_resolve_worktree_path <issue> [area]
   # Resolves actual worktree directory, checking current path first, then legacy.
@@ -135,9 +176,11 @@ pipeline_resolve_worktree_path() {
 pipeline_open_pane_verified() {
   # Usage: pipeline_open_pane_verified <working_dir> <prompt> [agent] [target_pane] [issue] [area]
   # Opens a side pane and verifies it survives startup (3-second grace period).
-  # On failure, retries once with re-resolved worktree path (if issue/area provided).
+  # Single attempt only - no internal retry. On failure, captures dead pane output
+  # for diagnosis via remain-on-exit, then cleans up.
   # stdout: pane_id on success, diagnostic token on failure
-  # Returns: 0 = success, 2 = PANE_DEAD, 3 = PATH_INVALID, 4 = RETRY_FAILED
+  # stderr: diagnosis info on failure (last 20 lines of dead pane output)
+  # Returns: 0 = success, 2 = PANE_DEAD, 3 = PATH_INVALID
   local workdir=$1
   local prompt=$2
   local agent=${3:-claude}
@@ -159,7 +202,7 @@ pipeline_open_pane_verified() {
     fi
   fi
 
-  # Phase 2: Open pane
+  # Phase 2: Open pane with remain-on-exit for failure diagnosis
   local pane_id
   pane_id=$(pipeline_open_pane "$workdir" "$prompt" "$agent" "$target_pane")
 
@@ -168,41 +211,27 @@ pipeline_open_pane_verified() {
     return 2
   fi
 
+  # Enable remain-on-exit so dead panes stay visible for diagnosis
+  tmux set-option -t "$pane_id" remain-on-exit on 2>/dev/null
+
   # Phase 3: Verify startup (3-second grace period)
   sleep 3
   if pipeline_pane_alive "$pane_id"; then
+    # Pane survived - disable remain-on-exit for normal operation
+    tmux set-option -t "$pane_id" remain-on-exit off 2>/dev/null
     echo "$pane_id"
     return 0
   fi
 
-  # Pane died — attempt one retry with re-resolved path
+  # Phase 4: Pane died - capture output for diagnosis, then clean up
   >&2 echo "[pipeline] Pane $pane_id died within 3s of startup"
+  local diagnosis
+  diagnosis=$(tmux capture-pane -t "$pane_id" -p 2>/dev/null | tail -20)
+  tmux kill-pane -t "$pane_id" 2>/dev/null
 
-  if [ -n "$issue" ]; then
-    local resolved_path
-    resolved_path=$(pipeline_resolve_worktree_path "$issue" "$area")
-    if [ $? -ne 0 ]; then
-      echo "PATH_INVALID"
-      return 3
-    fi
-
-    >&2 echo "[pipeline] Retrying with resolved path: $resolved_path"
-    pane_id=$(pipeline_open_pane "$resolved_path" "$prompt" "$agent" "$target_pane")
-
-    if [ -z "$pane_id" ]; then
-      echo "RETRY_FAILED"
-      return 4
-    fi
-
-    sleep 3
-    if pipeline_pane_alive "$pane_id"; then
-      echo "$pane_id"
-      return 0
-    fi
-
-    >&2 echo "[pipeline] Retry pane $pane_id also died"
-    echo "RETRY_FAILED"
-    return 4
+  if [ -n "$diagnosis" ]; then
+    >&2 echo "[pipeline] Last output from dead pane:"
+    >&2 echo "$diagnosis"
   fi
 
   echo "PANE_DEAD"


### PR DESCRIPTION
## Summary

- `pipeline_open_pane_verified`의 내부 retry를 제거하고 단일 시도로 변경
- 실패 시 `remain-on-exit`로 죽은 pane의 마지막 출력을 캡처하여 원인 진단 가능
- 새 헬퍼 함수 추가: `pipeline_pane_snapshot`, `pipeline_pane_orphan_cleanup`, `pipeline_kill_state_pane`
- 오케스트레이터용 3-layer 프로토콜 문서화 (pre-defense / execution / post-diagnosis)

## Background

Review pane 열기가 실패할 때, 오케스트레이터가 다른 bash 문법으로 재시도 + 함수 내부 retry가 겹쳐서 3-4개의 orphan pane이 생성되는 문제 발생. 근본 원인은 "출력 캡처 실패"가 아니라 "pane 즉시 사망 → 내부 retry → 외부 재시도" 체인.

## Changes

- `pipeline_open_pane_verified`: 내부 retry 제거, `remain-on-exit` 진단 추가
- `pipeline_pane_snapshot`: orphan 감지를 위한 pane ID 스냅샷
- `pipeline_pane_orphan_cleanup`: before/after diff로 orphan pane kill
- `pipeline_kill_state_pane`: state에 기록된 pane을 field명으로 kill
- `pane-lifecycle.md`: 3-layer 오케스트레이터 프로토콜 문서화
- `RETRY_FAILED` (rc=4) 반환 코드 제거

## Test plan

- [ ] `pipeline_open_pane_verified` 성공 시 pane ID 반환 확인
- [ ] 실패 시 stderr에 진단 정보 출력 확인
- [ ] `pipeline_pane_snapshot` + `pipeline_pane_orphan_cleanup` 조합으로 orphan 정리 확인
- [ ] `pipeline_kill_state_pane` 으로 state에 기록된 pane kill 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)