### PR TITLE
fix: dev-update resilience - apt lists cleanup and independent step execution (#51)

### DIFF
--- a/tools/docker/.bash_aliases
+++ b/tools/docker/.bash_aliases
@@ -10,26 +10,58 @@ alias ch="claude --chrome --dangerously-skip-permissions"
 
 alias cdx="codex --dangerously-bypass-approvals-and-sandbox"
 
-# 전체 업데이트 함수
+# 전체 업데이트 함수 (각 단계 독립 실행 - 하나 실패해도 나머지 계속)
 dev-update() {
   echo "=== Updating dev tools ==="
+  local failed=0
 
-  # System packages
-  sudo apt-get update && sudo apt-get upgrade -y && sudo rm -rf /var/lib/apt/lists/*
+  # System packages (손상된 apt lists 정리 후 업데이트)
+  echo "[1/4] System packages"
+  sudo rm -rf /var/lib/apt/lists/*
+  if sudo apt-get update && sudo apt-get upgrade -y; then
+    sudo rm -rf /var/lib/apt/lists/*
+    echo "  done"
+  else
+    echo "  SKIPPED (apt-get failed)"
+    sudo rm -rf /var/lib/apt/lists/*
+    ((failed++)) || true
+  fi
 
   # Claude Code CLI (native installer)
-  curl -fsSL https://claude.ai/install.sh | bash
+  echo "[2/4] Claude Code CLI"
+  if curl -fsSL https://claude.ai/install.sh | bash; then
+    echo "  done"
+  else
+    echo "  SKIPPED (install failed)"
+    ((failed++)) || true
+  fi
 
   # Codex CLI
-  sudo npm update -g @openai/codex
+  echo "[3/4] Codex CLI"
+  if sudo npm update -g @openai/codex; then
+    echo "  done"
+  else
+    echo "  SKIPPED (npm update failed)"
+    ((failed++)) || true
+  fi
 
   # pnpm (corepack)
-  sudo corepack prepare pnpm@latest --activate
+  echo "[4/4] pnpm"
+  if sudo corepack prepare pnpm@latest --activate; then
+    echo "  done"
+  else
+    echo "  SKIPPED (corepack failed)"
+    ((failed++)) || true
+  fi
 
   # 명령어 경로 캐시 초기화
   hash -r
 
-  echo "=== Update complete ==="
+  if [ "$failed" -gt 0 ]; then
+    echo "=== Update complete ($failed step(s) skipped) ==="
+  else
+    echo "=== Update complete ==="
+  fi
 }
 
 # 기존 tmux pane에서 환경 재로드

--- a/tools/docker/entrypoint.sh
+++ b/tools/docker/entrypoint.sh
@@ -71,8 +71,8 @@ ln -sfn /workspace/tools/docker/.bash_aliases /home/dev/.bash_aliases
 # .bash_aliases 로드 (dev-update 함수 사용)
 [ -f /home/dev/.bash_aliases ] && . /home/dev/.bash_aliases
 
-# 도구 업데이트
-dev-update
+# 도구 업데이트 (실패해도 컨테이너 시작 차단하지 않음)
+dev-update || echo "WARNING: dev-update failed (non-critical)"
 
 # 기존 명령 실행 (TPM 설치 → tmuxinator → tail)
 exec "$@"


### PR DESCRIPTION
## Summary

- `dev-update()` 각 단계를 독립 실행으로 변경 - 하나 실패해도 나머지 계속 진행
- apt-get update 전 손상된 apt lists 정리 추가 (LZ4 파싱 에러 방지)
- `entrypoint.sh`에 `dev-update || echo WARNING` 안전 장치 - `set -e`가 컨테이너 시작 차단하지 않도록

Closes #51

## Test plan

- [x] 컨테이너 내부에서 새 `dev-update` 함수 전체 실행 성공 확인
- [x] apt-get 실패 시 나머지 단계 계속 실행 확인
- [x] `set -e` 하에서 `|| echo WARNING` 안전 장치 동작 확인
- [ ] Docker 이미지 재빌드 후 `docker stop/start` 반복 안정성 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)