### PR TITLE
refactor: dev-log skill - detect existing worktree context

### DIFF
--- a/.agents/skills/dev-log/SKILL.md
+++ b/.agents/skills/dev-log/SKILL.md
@@ -9,7 +9,7 @@ Record-only skill. Task management via GitHub Issues, global rules in `CLAUDE.md
 
 > Area definitions, directory/repo mappings: [monorepo-layout.md](../../references/monorepo-layout.md)
 
-**Core strategy**: worktree isolation → scan indices → write records → lock merge → cleanup
+**Core strategy**: detect context → (worktree isolation if needed) → scan indices → write records → commit → (lock merge if needed) → cleanup
 
 ## Directory Structure
 
@@ -47,16 +47,24 @@ docs/{client|server|workspace}/
 > Use **worktree isolation** to prevent file conflicts when running parallel agents.
 > Detailed git commands: [worktree-merge.md](references/worktree-merge.md)
 
-### Phase 1: Create Worktree
+### Phase 0: Detect context
+
+Determine if already running inside a worktree.
+→ Commands: [worktree-merge.md § Phase 0](references/worktree-merge.md)
+
+- **In worktree** (`IN_WORKTREE=true`): use current worktree path. Skip Phase 1, 5, 6.
+- **Not in worktree**: follow the full flow (Phase 1 through 6).
+
+### Phase 1: Create worktree (skip if `IN_WORKTREE=true`)
 
 Timestamp-based worktree + branch. All file operations happen inside the worktree.
 → Commands: [worktree-merge.md § Phase 1](references/worktree-merge.md)
 
-### Phase 2: Check Context Before Recording
+### Phase 2: Check context before recording
 - Read `progress.index.md` + `findings.index.md` + `decisions.index.md` inside the worktree
 - Selectively read relevant sub-files only (do not read all)
 
-### Phase 3: Write Records (inside worktree)
+### Phase 3: Write records (inside worktree)
 - **Technical research**: Create `findings/findings.NNN-topic.md` + update `findings.index.md`
 - **Architecture decision**: Create `decisions/decision-NNN-topic.md` (draft) + update `decisions.index.md`
 - **Task completion**: Create/update `progress/progress.YYYY-MM-DD.md` + update `progress.index.md`
@@ -68,13 +76,13 @@ Timestamp-based worktree + branch. All file operations happen inside the worktre
 `git add docs/` → `git commit -m "docs: {type} - {summary}"`
 → Commands: [worktree-merge.md § Phase 4](references/worktree-merge.md)
 
-### Phase 5: Lock → Merge → Unlock
+### Phase 5: Lock → Merge → Unlock (skip if `IN_WORKTREE=true`)
 
 Acquire lock → rebase → fast-forward merge → release lock. Wait up to 60s if another agent holds the lock.
 On conflict/failure: always release lock, keep worktree intact.
 → Commands: [worktree-merge.md § Phase 5](references/worktree-merge.md)
 
-### Phase 6: Cleanup
+### Phase 6: Cleanup (skip if `IN_WORKTREE=true`)
 
 On success: remove worktree + delete branch. On failure: keep worktree for manual retry.
 → Commands: [worktree-merge.md § Phase 6](references/worktree-merge.md)

--- a/.agents/skills/dev-log/references/examples.md
+++ b/.agents/skills/dev-log/references/examples.md
@@ -34,7 +34,21 @@
 
 ---
 
-## Scenario 4: Parallel Agents (worktree isolation)
+## Scenario 4: In-worktree recording (existing worktree)
+
+**Situation**: Agent completes a root-repo task in worktree `refactor/skill-update` and calls `/dev-log`
+
+1. Phase 0: Detect `CWD` is under `.workspace/worktrees/` → `IN_WORKTREE=true`
+2. Read `docs/workspace/progress.index.md` inside the worktree
+3. Write `docs/workspace/progress/progress.2026-03-09.md` inside the worktree
+4. `git add docs/ && git commit -m "docs: progress - skill update"`
+5. **Done** - no lock merge, no cleanup. The parent task handles merge/PR.
+
+**Key**: Records stay on the task branch alongside the code changes. The parent workflow (merge or PR) includes them.
+
+---
+
+## Scenario 5: Parallel Agents (worktree isolation)
 
 **Situation**: Agent A (server progress) + Agent B (client findings) running concurrently
 

--- a/.agents/skills/dev-log/references/worktree-merge.md
+++ b/.agents/skills/dev-log/references/worktree-merge.md
@@ -4,10 +4,11 @@
 
 Worktree isolation + lock-based merge to prevent conflicts when parallel agents modify `docs/` simultaneously.
 
+Two modes based on context:
+
 ```
-Agent A: [create worktree] [write docs] [commit] [LOCK] [rebase+merge] [UNLOCK] [cleanup]
-Agent B: [create worktree] [write docs] [commit] ......[LOCK] [rebase+merge] [UNLOCK] [cleanup]
-                                                        ↑ wait
+Standalone:  [detect] [create worktree] [write docs] [commit] [LOCK] [rebase+merge] [UNLOCK] [cleanup]
+In worktree: [detect] ................ [write docs] [commit] ......................................
 ```
 
 ## Constants
@@ -23,7 +24,27 @@ LOCK_INTERVAL=5   # seconds
 
 > **Note**: The AI must resolve `$ROOT_REPO` before sourcing. Use the monorepo root directory where `.agents/` lives. Do not use `git rev-parse` - this monorepo has multiple independent git repos.
 
-## Phase 1: Create Worktree
+## Phase 0: Detect context
+
+Check if the current working directory is already inside a worktree under `.workspace/worktrees/`.
+
+```bash
+CWD="$(pwd)"
+if [[ "$CWD" == "$ROOT_REPO/.workspace/worktrees/"* ]]; then
+  IN_WORKTREE=true
+  WORKTREE_PATH="$CWD"
+  echo "In existing worktree: $WORKTREE_PATH"
+  echo "Skipping Phase 1, 5, 6 - records will be committed in this worktree"
+else
+  IN_WORKTREE=false
+  echo "Not in worktree - using full standalone flow"
+fi
+```
+
+- **`IN_WORKTREE=true`**: Use current path as `$WORKTREE_PATH`. Skip Phase 1 (create), Phase 5 (lock merge), Phase 6 (cleanup). The parent task owns the worktree lifecycle.
+- **`IN_WORKTREE=false`**: Follow the full flow below.
+
+## Phase 1: Create worktree (skip if `IN_WORKTREE=true`)
 
 ```bash
 TIMESTAMP=$(date +%Y%m%d-%H%M%S)
@@ -48,7 +69,7 @@ git commit -m "docs: {type} - {summary}"
 - `{type}`: progress, findings, or decision
 - Multiple types at once: `docs: progress + findings - {summary}`
 
-## Phase 5: Lock → Merge → Unlock
+## Phase 5: Lock → Merge → Unlock (skip if `IN_WORKTREE=true`)
 
 ### Acquire Lock
 
@@ -104,7 +125,7 @@ echo "Lock released. Merge successful."
 
 **Important**: Always execute `rmdir "$LOCK_FILE"` when exiting Phase 5 regardless of path.
 
-## Phase 6: Cleanup
+## Phase 6: Cleanup (skip if `IN_WORKTREE=true`)
 
 ### On Success
 


### PR DESCRIPTION
## Summary

dev-log 스킬이 이미 worktree 안에서 실행 중인지 감지하여 불필요한 worktree 생성/머지/클린업을 건너뛰도록 수정.

## Changes

- **Phase 0 추가**: CWD가 `.workspace/worktrees/` 하위인지 확인하여 `IN_WORKTREE` 플래그 설정
- **Phase 1, 5, 6**: `IN_WORKTREE=true`일 때 skip 조건 명시
- **examples.md**: In-worktree recording 시나리오 추가

## Behavior

| Context | Flow |
|---------|------|
| worktree 안 | detect → write → commit (부모 작업이 머지/PR 처리) |
| worktree 밖 | detect → create worktree → write → commit → lock merge → cleanup |