### PR TITLE
fix: resolve SHA 미갱신 + suggestion_only 전이 + python3 + model 문서화 (#161)

### DIFF
--- a/.agents/skills/dev-pipeline/SKILL.md
+++ b/.agents/skills/dev-pipeline/SKILL.md
@@ -7,7 +7,7 @@ description: Orchestrate /dev-build -> /dev-review -> resolve (direct) -> merge 
 
 Orchestrate build -> review -> resolve -> merge -> log for area-scoped issues.
 
-> CLI: `cd .agents/skills/dev-pipeline/scripts && python -m dev_pipeline <cmd>`
+> CLI: `cd .agents/skills/dev-pipeline/scripts && python3 -m dev_pipeline <cmd>`
 > Worktree: `.workspace/worktrees/{area}/issue-{N}` | State: `.workspace/pipeline/{area}/issue-{N}.state.json`
 
 ## Invariants
@@ -15,9 +15,9 @@ Orchestrate build -> review -> resolve -> merge -> log for area-scoped issues.
 1. **Headless review cwd is always monorepo root**. Never start `claude -p` from a worktree.
 2. **Feature-branch edits happen only in the issue worktree**.
 3. **gh commands use explicit repo selection** (`-R owner/name`).
-4. **Review dispatch always via `python -m dev_pipeline run`**. Never invoke review tools directly.
+4. **Review dispatch always via `python3 -m dev_pipeline run`**. Never invoke review tools directly.
 5. **Resolve runs directly in the pipeline session**, not as a headless sub-agent.
-6. **Merge lock held inside one CLI call** (`python -m dev_pipeline merge`).
+6. **Merge lock held inside one CLI call** (`python3 -m dev_pipeline merge`).
 7. **`run`/`cleanup` manage the issue lease internally.** `--owner manual` for interactive; `--owner pipeline` for automated.
 8. **All transient files are area-scoped** (`state`, `logs`, `messages`, `worktrees` under `.workspace/.../{area}/`).
 
@@ -31,6 +31,8 @@ Orchestrate build -> review -> resolve -> merge -> log for area-scoped issues.
 | `review_wait` | `review_dispatch` | Review not found + job failed | No |
 | `review_process` | `resolve` | Critical > 0 or Warning > 0 | No |
 | `review_process` | `merge` | Critical = 0 and Warning = 0 | No |
+| `review_process` | `suggestion_decide` | Suggestion > 0 only | No |
+| `suggestion_decide` | `resolve` or `merge` | AI decision | No |
 | `resolve` | `review_dispatch` | skipReview=false, fixes applied | No |
 | `resolve` | `merge` | skipReview=true | No |
 | `merge` | `log` | PR merged | No |
@@ -41,27 +43,27 @@ Only `review_dispatch -> review_wait` requires a turn break. All other transitio
 ## Workflow
 
 ### 0. Initialize / resume
-`python -m dev_pipeline init --area "$AREA" --issue "$ISSUE"`
-If state exists, resume from `.step`. On crash: `python -m dev_pipeline sync-state --issue "$ISSUE" --area "$AREA"`
+`python3 -m dev_pipeline init --area "$AREA" --issue "$ISSUE"`
+If state exists, resume from `.step`. On crash: `python3 -m dev_pipeline sync-state --issue "$ISSUE" --area "$AREA"`
 
 ### 1. build
-Pre: `python -m dev_pipeline step build --issue $ISSUE --area $AREA --phase setup`
+Pre: `python3 -m dev_pipeline step build --issue $ISSUE --area $AREA --phase setup`
 Act: `/dev-build root #$ISSUE`
-Post: `python -m dev_pipeline step build --issue $ISSUE --area $AREA --phase finalize` -> review_dispatch
+Post: `python3 -m dev_pipeline step build --issue $ISSUE --area $AREA --phase finalize` -> review_dispatch
 
 ### 2a. review_dispatch
-`python -m dev_pipeline step review-dispatch --issue $ISSUE --area $AREA [--tool $TOOL]`
+`python3 -m dev_pipeline step review-dispatch --issue $ISSUE --area $AREA [--tool $TOOL]`
 
 | action | Next |
 |---|---|
 | `found` | review_process (`data.reviewId`) |
-| `dispatch` | `python -m dev_pipeline run ... --pr $PR --tool $TOOL` in **background** -> **end turn** (do not sleep, poll, or output status; resume on task-notification only) |
+| `dispatch` | `python3 -m dev_pipeline run ... --pr $PR --tool $TOOL [--model $MODEL]` in **background** -> **end turn** (do not sleep, poll, or output status; resume on task-notification only) |
 | `error` | Stop, report |
 
 When action is `found`: extract `REVIEW_ID` from `data.reviewId` before calling Step 3.
 
 ### 2b. review_wait (on resume after task-notification)
-`python -m dev_pipeline step review-wait --issue $ISSUE --area $AREA`
+`python3 -m dev_pipeline step review-wait --issue $ISSUE --area $AREA`
 
 | action | Next |
 |---|---|
@@ -72,7 +74,7 @@ When action is `found`: extract `REVIEW_ID` from `data.reviewId` before calling 
 Extract `REVIEW_ID` from the step `data` JSON output before calling Step 3.
 
 ### 3. review_process
-`python -m dev_pipeline step review-process --issue $ISSUE --area $AREA --review-id $REVIEW_ID`
+`python3 -m dev_pipeline step review-process --issue $ISSUE --area $AREA --review-id $REVIEW_ID`
 
 | action | Next |
 |---|---|
@@ -83,16 +85,27 @@ Extract `REVIEW_ID` from the step `data` JSON output before calling Step 3.
 | `escalate` | Stop, report |
 
 **`suggestion_only` rules** (Critical=0, Warning=0, Suggestion>0; first matching rule wins):
-- Style/formatting only, all 1-line -> merge (auto)
-- Logic change or structural impact -> resolve then re-review (skipReview=false)
-- All trivial, count <= 3 -> resolve then merge (skipReview=true)
-- Otherwise -> merge (auto)
+- Style/formatting only, all 1-line -> `merge`
+- Logic change or structural impact -> `resolve-review`
+- All trivial, count <= 3 -> `resolve-skip`
+- Otherwise -> `merge`
+
+### 3b. suggestion_decide
+`python3 -m dev_pipeline step suggestion-decide --issue $ISSUE --area $AREA --decision $DECISION`
+
+`$DECISION` is one of: `merge`, `resolve-skip`, `resolve-review` (from the rules above).
+
+| action | Next |
+|---|---|
+| `merge` | merge |
+| `resolve` | resolve |
+| `error` | Stop, report |
 
 ### 4. resolve
-Pre: `python -m dev_pipeline step resolve --issue $ISSUE --area $AREA --phase setup`
+Pre: `python3 -m dev_pipeline step resolve --issue $ISSUE --area $AREA --phase setup`
 `data`: `reviewBody`, `comments` (JSON array), `worktreePath`
 Act: Fix code in worktree. `[CRITICAL]`/`[WARNING]`: must fix. `[SUGGESTION]`: fix if valid.
-Post: `python -m dev_pipeline step resolve --issue $ISSUE --area $AREA --phase finalize`
+Post: `python3 -m dev_pipeline step resolve --issue $ISSUE --area $AREA --phase finalize`
 
 | action | Next |
 |---|---|
@@ -100,7 +113,7 @@ Post: `python -m dev_pipeline step resolve --issue $ISSUE --area $AREA --phase f
 | `merge` | merge |
 
 ### 5. merge
-`python -m dev_pipeline step merge --issue $ISSUE --area $AREA`
+`python3 -m dev_pipeline step merge --issue $ISSUE --area $AREA`
 
 | action | Next |
 |---|---|
@@ -110,7 +123,7 @@ Post: `python -m dev_pipeline step resolve --issue $ISSUE --area $AREA --phase f
 
 ### 6. log + cleanup
 Act: `/dev-log`
-Post: `python -m dev_pipeline step log --issue $ISSUE --area $AREA --phase finalize` -> Done.
+Post: `python3 -m dev_pipeline step log --issue $ISSUE --area $AREA --phase finalize` -> Done.
 
 ## Constraints
 
@@ -118,7 +131,7 @@ Post: `python -m dev_pipeline step log --issue $ISSUE --area $AREA --phase final
 - **Auto-merge** when Critical=0 AND Warning=0, or user approves.
 - **User approval required** when round limit reached with Critical/Warning.
 - Source edits only in resolve step, only in the issue worktree.
-- On error: `python -m dev_pipeline escalation --issue "$ISSUE" --area "$AREA" --step "$STEP"`
+- On error: `python3 -m dev_pipeline escalation --issue "$ISSUE" --area "$AREA" --step "$STEP"`
 
 ## References
 

--- a/.agents/skills/dev-pipeline/references/process-lifecycle.md
+++ b/.agents/skills/dev-pipeline/references/process-lifecycle.md
@@ -48,7 +48,7 @@ High-level CLI interface that replaces inline Bash in SKILL.md (v3).
 
 ### Invocation
 
-`python -m dev_pipeline step <name> --issue N --area A [--phase setup|finalize] [--review-id N] [--tool T]`
+`python3 -m dev_pipeline step <name> --issue N --area A [--phase setup|finalize] [--review-id N] [--tool T] [--decision D]`
 
 ### Output contract
 
@@ -60,7 +60,7 @@ stderr emits human-readable log messages.
 
 ### Two patterns
 
-1. **Single call** (fully automated): `review-dispatch`, `review-wait`, `review-process`, `merge`
+1. **Single call** (fully automated): `review-dispatch`, `review-wait`, `review-process`, `suggestion-decide`, `merge`
    - Python handles the entire logic, returns action for next step routing
 2. **Two-phase** (AI skill invocation required): `build`, `resolve`, `log`
    - `--phase setup`: preparation before AI skill (fetch, state init, review fetch)

--- a/.agents/skills/dev-pipeline/references/recovery.md
+++ b/.agents/skills/dev-pipeline/references/recovery.md
@@ -7,7 +7,7 @@ Resume from state file on crash/disconnect. Jump to the `step` field - each step
 Step functions perform entry validation internally. Recovery procedure:
 
 1. Read `.step` from the state file
-2. `python -m dev_pipeline sync-state --issue N --area A` (syncs latest SHA and review ID from GitHub/git)
+2. `python3 -m dev_pipeline sync-state --issue N --area A` (syncs latest SHA and review ID from GitHub/git)
 3. Run the corresponding step command - the step function internally:
    - Checks worktree existence and state
    - Compares LOCAL_HEAD vs state SHA

--- a/.agents/skills/dev-pipeline/scripts/dev_pipeline/cli.py
+++ b/.agents/skills/dev-pipeline/scripts/dev_pipeline/cli.py
@@ -356,6 +356,7 @@ def cmd_step(args) -> int:
         step_review_dispatch,
         step_review_wait,
         step_review_process,
+        step_suggestion_decide,
         step_resolve_setup,
         step_resolve_finalize,
         step_merge,
@@ -374,6 +375,9 @@ def cmd_step(args) -> int:
         ("review-wait", None): lambda: step_review_wait(args.issue, args.area, monorepo_root),
         ("review-process", None): lambda: step_review_process(
             args.issue, args.area, monorepo_root, review_id=args.review_id,
+        ),
+        ("suggestion-decide", None): lambda: step_suggestion_decide(
+            args.issue, args.area, monorepo_root, decision=args.decision,
         ),
         ("resolve", "setup"): lambda: step_resolve_setup(args.issue, args.area, monorepo_root),
         ("resolve", "finalize"): lambda: step_resolve_finalize(args.issue, args.area, monorepo_root),
@@ -542,7 +546,7 @@ def main():
     # step
     _STEP_CHOICES = [
         "build", "review-dispatch", "review-wait", "review-process",
-        "resolve", "merge", "log",
+        "suggestion-decide", "resolve", "merge", "log",
     ]
     p_step = sub.add_parser("step", help="Execute a pipeline step")
     p_step.add_argument("name", choices=_STEP_CHOICES)
@@ -551,6 +555,7 @@ def main():
     p_step.add_argument("--phase", choices=["setup", "finalize"])
     p_step.add_argument("--review-id", type=int, default=0)
     p_step.add_argument("--tool", default="claude")
+    p_step.add_argument("--decision", default="", choices=["merge", "resolve-skip", "resolve-review"])
     p_step.set_defaults(func=cmd_step)
 
     # check-lease

--- a/.agents/skills/dev-pipeline/scripts/dev_pipeline/steps.py
+++ b/.agents/skills/dev-pipeline/scripts/dev_pipeline/steps.py
@@ -348,6 +348,65 @@ def step_review_process(
 
 
 # ---------------------------------------------------------------------------
+# 3b. suggestion_decide
+# ---------------------------------------------------------------------------
+
+def step_suggestion_decide(
+    issue: int, area: str, monorepo_root: Path, decision: str,
+) -> StepResult:
+    """Apply AI's suggestion_only decision: merge, resolve-skip, or resolve-review.
+
+    Called after step_review_process returns action=suggestion_only and the AI
+    decides how to handle suggestions.
+
+    Args:
+        decision: one of "merge", "resolve-skip", "resolve-review"
+    """
+    state = state_read(issue, area, monorepo_root)
+    round_num = state.review_resolve_round
+
+    if decision == "merge":
+        state_update(issue, area, monorepo_root, {
+            "step": "merge",
+            "reviewResolveRound": round_num + 1,
+        })
+        log_transition(
+            issue, area, monorepo_root,
+            "review_process", "merge", "suggestion_only -> merge",
+        )
+        return StepResult(action="merge", data={"round": round_num + 1})
+
+    if decision == "resolve-skip":
+        state_update(issue, area, monorepo_root, {
+            "step": "resolve",
+            "skipReview": True,
+            "reviewResolveRound": round_num + 1,
+        })
+        log_transition(
+            issue, area, monorepo_root,
+            "review_process", "resolve", "suggestion_only -> resolve (skipReview)",
+        )
+        return StepResult(action="resolve", data={"round": round_num + 1})
+
+    if decision == "resolve-review":
+        state_update(issue, area, monorepo_root, {
+            "step": "resolve",
+            "skipReview": False,
+            "reviewResolveRound": round_num + 1,
+        })
+        log_transition(
+            issue, area, monorepo_root,
+            "review_process", "resolve", "suggestion_only -> resolve (re-review)",
+        )
+        return StepResult(action="resolve", data={"round": round_num + 1})
+
+    return StepResult(
+        action="error",
+        data={"error": f"invalid decision: {decision}"},
+    )
+
+
+# ---------------------------------------------------------------------------
 # 4. resolve (setup + finalize)
 # ---------------------------------------------------------------------------
 
@@ -447,11 +506,11 @@ def step_resolve_finalize(issue: int, area: str, monorepo_root: Path) -> StepRes
     if has_staged_changes(str(wt)):
         commit(str(wt), f"fix: address review comments (#{issue})")
         push_safely(str(wt))
-        new_sha = rev_parse_head(str(wt))
-        if new_sha:
-            state_update(issue, area, monorepo_root, {"lastCommitSha": new_sha})
-    else:
-        new_sha = state.last_commit_sha
+
+    # Always read current HEAD - AI may have committed directly before finalize
+    new_sha = rev_parse_head(str(wt))
+    if new_sha and new_sha != state.last_commit_sha:
+        state_update(issue, area, monorepo_root, {"lastCommitSha": new_sha})
 
     if state.skip_review:
         state_update(issue, area, monorepo_root, {"step": "merge"})

--- a/.agents/skills/dev-pipeline/tests/test_steps.py
+++ b/.agents/skills/dev-pipeline/tests/test_steps.py
@@ -27,6 +27,7 @@ from dev_pipeline.steps import (
     step_review_dispatch,
     step_review_wait,
     step_review_process,
+    step_suggestion_decide,
     step_resolve_setup,
     step_resolve_finalize,
     step_merge,
@@ -414,6 +415,82 @@ class TestReviewProcess:
 
 
 # ---------------------------------------------------------------------------
+# suggestion decide (fix #2 + #3)
+# ---------------------------------------------------------------------------
+
+class TestSuggestionDecide:
+    def test_merge(self, monorepo_root):
+        _write_state(
+            monorepo_root, 42, "workspace",
+            step=PipelineStep.REVIEW_PROCESS,
+            review_resolve_round=2,
+        )
+
+        result = step_suggestion_decide(42, "workspace", monorepo_root, decision="merge")
+        assert result.action == "merge"
+        assert result.data["round"] == 3
+
+        state = state_read(42, "workspace", monorepo_root)
+        assert state.step == PipelineStep.MERGE
+        assert state.review_resolve_round == 3
+
+    def test_resolve_skip(self, monorepo_root):
+        _write_state(
+            monorepo_root, 42, "workspace",
+            step=PipelineStep.REVIEW_PROCESS,
+            review_resolve_round=1,
+        )
+
+        result = step_suggestion_decide(42, "workspace", monorepo_root, decision="resolve-skip")
+        assert result.action == "resolve"
+        assert result.data["round"] == 2
+
+        state = state_read(42, "workspace", monorepo_root)
+        assert state.step == PipelineStep.RESOLVE
+        assert state.skip_review is True
+        assert state.review_resolve_round == 2
+
+    def test_resolve_review(self, monorepo_root):
+        _write_state(
+            monorepo_root, 42, "workspace",
+            step=PipelineStep.REVIEW_PROCESS,
+            review_resolve_round=0,
+        )
+
+        result = step_suggestion_decide(42, "workspace", monorepo_root, decision="resolve-review")
+        assert result.action == "resolve"
+        assert result.data["round"] == 1
+
+        state = state_read(42, "workspace", monorepo_root)
+        assert state.step == PipelineStep.RESOLVE
+        assert state.skip_review is False
+        assert state.review_resolve_round == 1
+
+    def test_invalid_decision(self, monorepo_root):
+        _write_state(
+            monorepo_root, 42, "workspace",
+            step=PipelineStep.REVIEW_PROCESS,
+        )
+
+        result = step_suggestion_decide(42, "workspace", monorepo_root, decision="invalid")
+        assert result.action == "error"
+
+    def test_round_counter_increments(self, monorepo_root):
+        """Fix #3: round counter increments on suggestion_only path."""
+        _write_state(
+            monorepo_root, 42, "workspace",
+            step=PipelineStep.REVIEW_PROCESS,
+            review_resolve_round=3,
+        )
+
+        result = step_suggestion_decide(42, "workspace", monorepo_root, decision="resolve-skip")
+
+        state = state_read(42, "workspace", monorepo_root)
+        assert state.review_resolve_round == 4
+        assert result.data["round"] == 4
+
+
+# ---------------------------------------------------------------------------
 # resolve setup
 # ---------------------------------------------------------------------------
 
@@ -508,6 +585,7 @@ class TestResolveFinalize:
 
         monkeypatch.setattr(f"{S}.add_all", lambda wt: True)
         monkeypatch.setattr(f"{S}.has_staged_changes", lambda wt: False)
+        monkeypatch.setattr(f"{S}.rev_parse_head", lambda wt: "a" * 40)
 
         result = step_resolve_finalize(42, "workspace", monorepo_root)
         assert result.action == "merge"
@@ -524,9 +602,30 @@ class TestResolveFinalize:
 
         monkeypatch.setattr(f"{S}.add_all", lambda wt: True)
         monkeypatch.setattr(f"{S}.has_staged_changes", lambda wt: False)
+        monkeypatch.setattr(f"{S}.rev_parse_head", lambda wt: "a" * 40)
 
         result = step_resolve_finalize(42, "workspace", monorepo_root)
         assert result.action == "re_review"
+
+    def test_ai_committed_directly_updates_sha(self, monorepo_root, monkeypatch):
+        """Fix #1: AI commits before finalize -> SHA updated even with no staged changes."""
+        _write_state(
+            monorepo_root, 42, "workspace",
+            step=PipelineStep.RESOLVE,
+            skip_review=False,
+            last_commit_sha="a" * 40,
+        )
+
+        monkeypatch.setattr(f"{S}.add_all", lambda wt: True)
+        monkeypatch.setattr(f"{S}.has_staged_changes", lambda wt: False)
+        # HEAD differs from state - AI committed directly
+        monkeypatch.setattr(f"{S}.rev_parse_head", lambda wt: "b" * 40)
+
+        result = step_resolve_finalize(42, "workspace", monorepo_root)
+        assert result.action == "re_review"
+
+        state = state_read(42, "workspace", monorepo_root)
+        assert state.last_commit_sha == "b" * 40
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes #161

dev-pipeline #153 실행 중 발견된 5건의 버그를 수정합니다.

## Changes

| File | Change |
|------|--------|
| `scripts/dev_pipeline/steps.py` | #1: `step_resolve_finalize`에서 항상 HEAD를 읽어 `lastCommitSha` 갱신 |
| `scripts/dev_pipeline/steps.py` | #2: `step_suggestion_decide` 함수 추가 - suggestion_only 상태 전이 처리 |
| `scripts/dev_pipeline/cli.py` | #2: `suggestion-decide` step 파서 및 dispatch 추가 |
| `SKILL.md` | #4: `python` -> `python3` 일괄 치환 (16곳) |
| `SKILL.md` | #5: `--model` 인자 문서화 + `suggestion-decide` 워크플로우 추가 |
| `references/process-lifecycle.md` | #4: `python3` 치환 + `suggestion-decide` 문서화 |
| `references/recovery.md` | #4: `python3` 치환 |
| `tests/test_steps.py` | #1: AI 직접 커밋 시 SHA 갱신 테스트, #2: suggestion_decide 5개 테스트 |

## Type

- [ ] feat
- [x] fix
- [ ] refactor
- [ ] docs
- [ ] test
- [ ] chore

## Checklist

### 작성자 확인 (Author)

- [x] 코드가 정상 동작하는 것을 로컬에서 확인했습니다
- [x] 관련 테스트를 추가하거나 수정했습니다
- [x] 불필요한 console.log / 디버깅 코드를 제거했습니다

### Reviewer

- [ ] Changes match the PR description
- [ ] Edge cases are handled appropriately
- [ ] No security issues found

## Notes

- Fix #1: `step_resolve_finalize`가 `has_staged_changes()` 결과와 무관하게 현재 HEAD를 읽어 state SHA와 비교 후 갱신
- Fix #2: `step_suggestion_decide` step 추가로 AI 판단(merge/resolve-skip/resolve-review)을 받아 state 전이 수행
- Fix #3: #2의 `step_suggestion_decide`에서 `reviewResolveRound` 증가 포함하여 자동 해결
- Fix #4: 환경에 `python` 심볼릭 링크 없으므로 `python3`으로 통일
- Fix #5: `--model` 인자를 SKILL.md Step 2a dispatch 라인에 문서화
