### PR TITLE
fix: pipeline review-wait pending / round counter / normalizer bugs (#170)

### DIFF
--- a/.agents/skills/dev-pipeline/SKILL.md
+++ b/.agents/skills/dev-pipeline/SKILL.md
@@ -69,6 +69,7 @@ When action is `found`: extract `REVIEW_ID` from `data.reviewId` before calling 
 |---|---|
 | `review` | review_process (`data.reviewId`) |
 | `retry` | review_dispatch (`data.tool` if present) |
+| `pending` | review_wait (re-call after brief wait; review job still running) |
 | `escalate` | Stop, report `data.reason` |
 
 Extract `REVIEW_ID` from the step `data` JSON output before calling Step 3.

--- a/.agents/skills/dev-pipeline/scripts/dev_pipeline/review_normalizer.py
+++ b/.agents/skills/dev-pipeline/scripts/dev_pipeline/review_normalizer.py
@@ -217,7 +217,7 @@ def parse_review_body_full(body: str) -> ParsedReview:
             current_item_lines = []
             current_severity = None
             section = None
-        elif section and re.match(r"^\d+\.", stripped):
+        elif section and re.match(r"^\d+\.", stripped) and not line.startswith((" ", "\t")):
             _flush_item()
             current_item_lines = [line]
             current_severity = section

--- a/.agents/skills/dev-pipeline/scripts/dev_pipeline/steps.py
+++ b/.agents/skills/dev-pipeline/scripts/dev_pipeline/steps.py
@@ -254,7 +254,15 @@ def step_review_wait(issue: int, area: str, monorepo_root: Path) -> StepResult:
             message=f"[step:review_wait] escalate: {job.status.value}",
         )
 
-    # Other status (success but no review posted, running but stale, etc.)
+    # Review job still in progress - caller should poll again
+    if job.status == ReviewJobStatus.RUNNING:
+        return StepResult(
+            action="pending",
+            data={"reason": "review job still running"},
+            message="[step:review_wait] pending: review job still running",
+        )
+
+    # Other status (success but no review posted, etc.)
     return StepResult(
         action="escalate",
         data={"reason": f"job status={job.status.value} but no review on GitHub"},
@@ -338,8 +346,9 @@ def step_review_process(
             action="suggestion_only",
             data={
                 "counts": counts_dict,
-                "round": round_num,
+                "round": round_num + 1,
                 "reviewId": review_id,
+                "reviewBody": body,
             },
         )
 

--- a/.agents/skills/dev-pipeline/tests/test_review_normalizer.py
+++ b/.agents/skills/dev-pipeline/tests/test_review_normalizer.py
@@ -149,6 +149,22 @@ def test_dataclass_fields():
     assert counts.suggestion == 3
 
 
+def test_indented_sub_list_not_counted_as_new_item():
+    """Bug 3 fix: indented numbered sub-list items must not be counted as top-level items."""
+    body = """## Review Summary
+
+### Suggestion
+
+1. doctor.py - Connection not closed properly
+   1. schema_ver == 0 raises an unhandled error
+   2. If _check_orphan fails, connection leaks
+2. test_cli.py - No tests for the new CLI commands
+
+"""
+    counts = parse_review_body(body)
+    assert counts.suggestion == 2
+
+
 # --- normalize_codex_output tests ---
 
 

--- a/.agents/skills/dev-pipeline/tests/test_steps.py
+++ b/.agents/skills/dev-pipeline/tests/test_steps.py
@@ -286,6 +286,18 @@ class TestReviewWait:
         result = step_review_wait(42, "workspace", monorepo_root)
         assert result.action == "escalate"
 
+    def test_running_job_returns_pending(self, monorepo_root, monkeypatch):
+        """Bug 1 fix: job status=running returns pending instead of escalate."""
+        _write_state(
+            monorepo_root, 42, "workspace",
+            step=PipelineStep.REVIEW_WAIT,
+            review_job=ReviewJob(status=ReviewJobStatus.RUNNING, tool="claude"),
+        )
+        monkeypatch.setattr(f"{S}.check_review_exists", lambda *a, **kw: None)
+
+        result = step_review_wait(42, "workspace", monorepo_root)
+        assert result.action == "pending"
+
 
 # ---------------------------------------------------------------------------
 # review process
@@ -365,6 +377,39 @@ class TestReviewProcess:
 
         result = step_review_process(42, "workspace", monorepo_root, review_id=100)
         assert result.action == "suggestion_only"
+
+    def test_suggestion_only_round_incremented(self, monorepo_root, monkeypatch):
+        """Bug 2 fix: suggestion_only returns round_num + 1, not round_num."""
+        _write_state(
+            monorepo_root, 42, "workspace",
+            step=PipelineStep.REVIEW_PROCESS,
+            review_resolve_round=1,
+        )
+        monkeypatch.setattr(
+            f"{S}.fetch_review",
+            lambda *a, **kw: {"state": "COMMENTED", "body": "..."},
+        )
+        monkeypatch.setattr(f"{S}.parse_review_body", lambda b: ReviewCounts(0, 0, 2))
+
+        result = step_review_process(42, "workspace", monorepo_root, review_id=100)
+        assert result.action == "suggestion_only"
+        assert result.data["round"] == 2
+
+    def test_suggestion_only_includes_review_body(self, monorepo_root, monkeypatch):
+        """Bug 4 fix: suggestion_only data includes reviewBody for AI decision."""
+        _write_state(
+            monorepo_root, 42, "workspace",
+            step=PipelineStep.REVIEW_PROCESS,
+        )
+        monkeypatch.setattr(
+            f"{S}.fetch_review",
+            lambda *a, **kw: {"state": "COMMENTED", "body": "review body content"},
+        )
+        monkeypatch.setattr(f"{S}.parse_review_body", lambda b: ReviewCounts(0, 0, 1))
+
+        result = step_review_process(42, "workspace", monorepo_root, review_id=100)
+        assert result.action == "suggestion_only"
+        assert result.data["reviewBody"] == "review body content"
 
     def test_suggestion_at_round_limit_is_clean(self, monorepo_root, monkeypatch):
         _write_state(


### PR DESCRIPTION
## Summary

Closes #170

PR #167 (issue #85) 파이프라인 5라운드 실행 중 실증 확인된 4개 버그를 수정합니다.

## Changes

| File | Change |
|------|--------|
| `steps.py` | Bug 1: `step_review_wait` - `RUNNING` status에 `pending` 반환 추가 |
| `steps.py` | Bug 2: `step_review_process` - `suggestion_only` 경로에서 `round_num + 1` 반환 |
| `steps.py` | Bug 4: `step_review_process` - `suggestion_only` data에 `reviewBody` 포함 |
| `review_normalizer.py` | Bug 3: 들여쓰인 번호 하위 목록을 최상위 항목으로 오파싱하던 버그 수정 |
| `SKILL.md` | `review_wait` 액션 테이블에 `pending` 행 추가 |
| `test_steps.py` | Bug 1, 2, 4 회귀 테스트 추가 |
| `test_review_normalizer.py` | Bug 3 회귀 테스트 추가 |

## Type

- [x] fix — Bug fix

## Checklist

### 작성자 확인 (Author)

- [x] 코드가 정상 동작하는 것을 로컬에서 확인했습니다
- [x] 관련 테스트를 추가하거나 수정했습니다
- [x] 불필요한 console.log / 디버깅 코드를 제거했습니다

## Notes

**Bug 1 (Critical):** `_FAILED_STATUSES` frozenset에 `RUNNING`이 없어 task-notification 직후 `claude -p`가 아직 실행 중인 상태에서 review-wait를 호출하면 항상 escalate로 떨어지던 문제. `pending` action을 추가해 호출자가 재시도할 수 있도록 함.

**Bug 2 (Medium):** `suggestion_only` 경로에서 `review_resolve_round` state 업데이트는 `suggestion_decide`에서 하지만, 반환 data의 `round` 필드는 증가되지 않은 값을 반환하던 문제. `round_num + 1`로 수정.

**Bug 3 (Medium):** `parse_review_body_full`에서 `stripped` 기준으로 `^\d+\.` 매칭 시 들여쓰인 하위 목록 항목도 새 최상위 항목으로 카운트되던 문제. 원본 `line`으로 들여쓰기 여부를 판단하도록 수정.

**Bug 4 (Low):** `suggestion_only` data에 `reviewBody`가 없어 에이전트가 suggestion 내용을 보려면 `resolve --phase setup`을 우회 호출해야 했던 문제. `reviewBody` 필드 추가.
