### PR TITLE
fix: agent tracker legacy Bash safety hotfix (#108)

### DIFF
--- a/tools/agent-tracker/lib/collect.sh
+++ b/tools/agent-tracker/lib/collect.sh
@@ -96,6 +96,10 @@ _collect_agents() {
 
 _collect_claude_pane() {
   local pane_id=$1 sidecar_dir=$2 pane_addr=$3
+
+  # Path traversal guard: pane_id must be %N (digits only) (#108)
+  [[ ! "$pane_id" =~ ^%[0-9]+$ ]] && return
+
   local pane_file="${pane_id#%}"
   local sidecar_path="${sidecar_dir}/${pane_file}.json"
 
@@ -103,7 +107,9 @@ _collect_claude_pane() {
   local tok_used=0 tok_total=0 tok_pct=0 tok_source="unknown" tok_fresh=true
 
   if [[ -f "$sidecar_path" ]]; then
-    # Read sidecar: single jq call, normalize text to single-line, output @tsv.
+    # Read sidecar: single jq call, normalize text to single-line.
+    # Use RS=\x1e (non-whitespace) so empty fields are never collapsed by read (#108).
+    # task/activity are base64-encoded to survive any control chars in values (#108).
     # Includes tokens_updated_at for independent token freshness tracking (#74).
     local raw
     raw=$(jq -r '[
@@ -112,16 +118,18 @@ _collect_claude_pane() {
       (.tokens.pct // 0 | tostring),
       (.tokens.used // 0 | tostring),
       (.tokens.max // 0 | tostring),
-      ((.task // "-") | gsub("[\\n\\t\\r]"; " ") | gsub("  +"; " ")),
-      ((.activity // "") | gsub("[\\n\\t\\r]"; " ") | gsub("  +"; " ")),
+      ((.task // "-") | gsub("[\\n\\r]"; " ") | gsub("  +"; " ") | @base64),
+      ((.activity // "") | gsub("[\\n\\r]"; " ") | gsub("  +"; " ") | @base64),
       (.updated_at // 0 | tostring),
       (.tokens_updated_at // 0 | tostring)
-    ] | @tsv' "$sidecar_path" 2>/dev/null)
+    ] | join("\u001e")' "$sidecar_path" 2>/dev/null)
 
     if [[ -n "$raw" ]]; then
-      local updated_at tokens_updated_at
-      IFS=$'\t' read -r model status tok_pct tok_used tok_total \
-        task activity updated_at tokens_updated_at <<< "$raw"
+      local updated_at tokens_updated_at _task_b64 _act_b64
+      IFS=$'\x1e' read -r model status tok_pct tok_used tok_total \
+        _task_b64 _act_b64 updated_at tokens_updated_at <<< "$raw"
+      task=$(printf '%s' "$_task_b64" | base64 -d 2>/dev/null)
+      activity=$(printf '%s' "$_act_b64" | base64 -d 2>/dev/null)
 
       tok_source="sidecar"
 
@@ -136,17 +144,23 @@ _collect_claude_pane() {
         (( tok_age > STALE_THRESHOLD_SECS )) && tok_fresh=false
       fi
 
-      # Status staleness: non-idle without recent update → reset (#47)
-      if [[ "$status" != "idle" && -n "$updated_at" && "$updated_at" != "0" ]]; then
+      # Zero tokens → no token data present yet; source unknown (#108)
+      if [[ "$tok_used" == "0" && "$tok_total" == "0" ]]; then
+        tok_source="unknown"
+      fi
+
+      # Status staleness: non-idle/non-done without recent update → stale (#47, #108)
+      if [[ "$status" != "idle" && "$status" != "done" && \
+            -n "$updated_at" && "$updated_at" != "0" ]]; then
         local age=$(( now_epoch - ${updated_at%.*} ))
         if (( age > STALE_THRESHOLD_SECS )); then
-          status="idle"
+          status="stale"
           activity=""
         fi
       fi
     else
-      # jq failed to parse sidecar → unknown, not silent idle (#72)
-      status="unknown"
+      # jq failed to parse sidecar → fault (partial write / corrupt) (#108)
+      status="fault"
     fi
 
     # Augment idle status from pane scraping (spinner detection)
@@ -192,8 +206,9 @@ _collect_claude_pane() {
     fi
   fi
 
-  # Status promotion: "(Done) " prefix → done
-  if [[ "$status" == "idle" && "$task" == "(Done) "* ]]; then
+  # Status promotion: "(Done) " prefix → done; unconditional so pane-scrape
+  # spinner cannot mask a completed task (#108)
+  if [[ "$task" == "(Done) "* ]]; then
     status="done"
   fi
 
@@ -439,12 +454,17 @@ _collect_orchestrator() {
     IFS=$'\t' read -r area batch_id n_done n_active n_pending n_blocked n_failed \
       n_total orch_pid orch_started_at created_at <<< "$meta_tsv"
 
-    # ── Batch liveness ──
-    _check_pid_alive "$orch_pid" "$orch_started_at" || continue
+    # ── Batch liveness — dead PIDs are shown explicitly, not hidden (#108) ──
+    local batch_alive=true
+    _check_pid_alive "$orch_pid" "$orch_started_at" || batch_alive=false
 
     local n_terminal=$(( n_done + n_failed ))
     local batch_status="active"
-    (( n_terminal >= n_total )) && batch_status="done"
+    if ! $batch_alive; then
+      batch_status="dead"
+    elif (( n_terminal >= n_total )); then
+      batch_status="done"
+    fi
 
     # ── Elapsed ──
     local elapsed_str=""

--- a/tools/agent-tracker/lib/render.sh
+++ b/tools/agent-tracker/lib/render.sh
@@ -30,7 +30,7 @@ render_dashboard() {
 
   # ── Extract agent data from snapshot (single jq call for all rows) ──
   local -a agent_rows=()
-  local n_working=0 n_plan=0 n_idle=0 n_total=0
+  local n_working=0 n_plan=0 n_idle=0 n_stale=0 n_total=0
 
   local agents_tsv
   agents_tsv=$(printf '%s' "$snapshot" | jq -r '
@@ -49,6 +49,7 @@ render_dashboard() {
       case "$status" in
         working|needs-input) (( n_working++ )) ;;
         plan)                (( n_plan++ ))    ;;
+        stale|fault|unknown) (( n_stale++ ))   ;;
         *)                   (( n_idle++ ))    ;;
       esac
 
@@ -184,7 +185,8 @@ render_dashboard() {
 
   # ── Footer ──
   local n_stat="(${n_working} working"
-  (( n_plan > 0 )) && n_stat+=", ${n_plan} plan"
+  (( n_plan > 0 ))  && n_stat+=", ${n_plan} plan"
+  (( n_stale > 0 )) && n_stat+=", ${n_stale} stale"
   n_stat+=", ${n_idle} idle)"
 
   local left_colored="${GREEN}●${R} ${GRAY}Active: ${n_total} agents ${n_stat}${R}"
@@ -248,6 +250,7 @@ _render_orchestrator() {
 
     h_color="$GOLD"
     [[ "$batch_status" == "done" ]] && h_color="$BLUE"
+    [[ "$batch_status" == "dead" ]] && h_color="$ROSE"
 
     printf "${GRAY}║${R}  ${BOLD}${h_color}%s${R}%*s${GRAY}%s${R}  ${GRAY}║${R}" \
       "$h_left" "$hgap" "" "$h_right"
@@ -337,6 +340,9 @@ _render_orchestrator() {
     if [[ "$batch_status" == "done" ]]; then
       batch_label="${BLUE}[DONE]${R}"
       batch_label_plain="[DONE]"
+    elif [[ "$batch_status" == "dead" ]]; then
+      batch_label="${ROSE}[DEAD]${R}"
+      batch_label_plain="[DEAD]"
     fi
 
     local of_dw bl_dw bl_extra fp

--- a/tools/agent-tracker/lib/util.sh
+++ b/tools/agent-tracker/lib/util.sh
@@ -86,6 +86,8 @@ status_badge() {
     needs-input)  printf "${ROSE}◉ wait${R}" ;;
     error)        printf "${ROSE}✖ err ${R}" ;;
     done)         printf "${BLUE}✓ done${R}" ;;
+    stale)        printf "${GOLD}~ stal${R}" ;;
+    fault)        printf "${ROSE}! flt ${R}" ;;
     unknown)      printf "${ROSE}? unkn${R}" ;;
     *)            printf "${GRAY}○ idle${R}" ;;
   esac


### PR DESCRIPTION
## PR 제목

fix: agent tracker legacy Bash safety hotfix (#108)

## Summary

Closes #108

Targeted correctness hotfix for the agent-tracker Bash dashboard. Fixes 6 live bugs that caused misreported states, hidden orchestrators, and incorrect token display.

## Changes

| File | Change |
|------|--------|
| `tools/agent-tracker/lib/collect.sh` | Fix `@tsv` field-collapse bug, token source semantics, stale/fault status, dead orchestrator display, done-task override, pane_id path validation |
| `tools/agent-tracker/lib/util.sh` | Add `stale` and `fault` cases to `status_badge` |
| `tools/agent-tracker/lib/render.sh` | Track `n_stale` counter separately; render dead orchestrator with `[DEAD]` in ROSE |

## Type

- [x] fix — Bug fix

## Checklist

### 작성자 확인 (Author)

- [x] 코드가 정상 동작하는 것을 로컬에서 확인했습니다
- [ ] 관련 테스트를 추가하거나 수정했습니다
- [x] 불필요한 console.log / 디버깅 코드를 제거했습니다

### Reviewer

- [ ] Changes match the PR description
- [ ] Edge cases are handled appropriately
- [ ] No security issues found

## Notes

Six bugs fixed:

1. **@tsv field collapse** - `IFS=$'\t' read` collapses consecutive tab separators (bash whitespace-IFS semantics), causing `updated_at` to shift into `activity` when activity is empty. Fixed by replacing `@tsv` + tab-IFS with `join("\u001e")` + `IFS=$'\x1e'` (non-whitespace delimiter). `task` and `activity` are additionally `@base64`-encoded to survive embedded control chars.

2. **Dead orchestrator hidden** - `_check_pid_alive || continue` silently discarded dead batches. Fixed by tracking `batch_alive` and setting `batch_status="dead"`, rendering with ROSE color and `[DEAD]` label instead of hiding.

3. **Token source/freshness when 0/0** - Sidecar present but no token data yet showed `source=sidecar, fresh=true`. Fixed: `tok_used==0 && tok_total==0` sets `tok_source="unknown"`, rendering `   ?` bar.

4. **Done task shows as working** - `_infer_status_from_pane` spinner detection ran before the `(Done)` prefix check, overriding `idle` → `working`. Fixed by making the `(Done) ` prefix check unconditional (removed `status=="idle"` guard).

5. **Path traversal guard** - `pane_id` is used directly in sidecar file path. Added `[[ "$pane_id" =~ ^%[0-9]+$ ]] || return` guard.

6. **stale/fault/dead/unknown separated from idle** - Stale sidecar data now sets `status="stale"` (was `idle`). Parse failure sets `status="fault"` (was `unknown`). `done` status is excluded from staleness check. Footer counter tracks `n_stale` separately.
