### PR TITLE
feat: writer contract alignment (#110)

### DIFF
--- a/.agents/skills/dev-pipeline/scripts/dev_pipeline/models.py
+++ b/.agents/skills/dev-pipeline/scripts/dev_pipeline/models.py
@@ -171,7 +171,7 @@ class PipelineState:
 
         return cls(
             version=d.get("version", 2),
-            issue=d.get("issue", 0),
+            issue=int(d.get("issue") or 0),
             area=d.get("area", ""),
             pr=d.get("pr", 0),
             branch=d.get("branch", ""),

--- a/tools/agent-tracker/hooks/on-status.sh
+++ b/tools/agent-tracker/hooks/on-status.sh
@@ -66,6 +66,9 @@ case "$event" in
   UserPromptSubmit)
     task=$(printf '%s' "$input" | jq -r '
       .prompt // "" |
+      gsub("\\u001b\\[[0-9;?]*[A-Za-z]"; "") |
+      gsub("\\u001b][^\u0007]*\u0007"; "") |
+      gsub("\\u001b."; "") |
       gsub("\n"; " ") | gsub("  +"; " ") |
       gsub("[[:cntrl:]]"; "") |
       ltrimstr(" ") | rtrimstr(" ") |
@@ -111,6 +114,9 @@ case "$event" in
           TaskUpdate:   .taskId
         } | .[$tn] // "" |
         tostring |
+        gsub("\\u001b\\[[0-9;?]*[A-Za-z]"; "") |
+        gsub("\\u001b][^\u0007]*\u0007"; "") |
+        gsub("\\u001b."; "") |
         gsub("\n"; " ") | gsub("  +"; " ") |
         gsub("[[:cntrl:]]"; "") |
         ltrimstr(" ") | rtrimstr(" ")

--- a/tools/agent-tracker/hooks/on-statusline.sh
+++ b/tools/agent-tracker/hooks/on-statusline.sh
@@ -53,7 +53,7 @@ _precomputed="${TRANSCRIPT_TOKENS:-0}"
 # Build jq expression for the merge.
 # Token priority: pre-computed > current_usage > used_percentage reverse-calc > 0.
 jq_expr='
-  ($input.model.display_name // $input.model.id // "Claude") as $model |
+  ($input.model.display_name // $input.model.id) as $model_raw |
   ($input.context_window.context_window_size // 200000) as $max_tokens |
   (($input.context_window.used_percentage // 0) | floor) as $pct |
   (
@@ -66,13 +66,13 @@ jq_expr='
       ($max_tokens * $pct / 100 | floor)
     else 0 end
   ) as $used_tokens |
-  $existing * {
+  ($existing * {
     schema_version: "v2",
     pane_id: $pane_id,
     session_name: $session,
     tmux_server: $tmux_socket,
     session_id: ($input.session_id // $existing.session_id // null),
-    model: $model,
+    model: ($model_raw // $existing.model // "unknown"),
     tokens: {
       used: $used_tokens,
       max: $max_tokens,
@@ -80,9 +80,9 @@ jq_expr='
     },
     cwd: ($input.cwd // $existing.cwd // null),
     transcript_path: ($input.transcript_path // $existing.transcript_path // null),
-    updated_at: now,
-    tokens_updated_at: now
-  }
+    updated_at: now
+  }) |
+  if $used_tokens > 0 then . + { tokens_updated_at: now } else . end
 '
 
 # Locked read-modify-write to prevent race with on-status.sh

--- a/tools/agent-tracker/lib/collect.sh
+++ b/tools/agent-tracker/lib/collect.sh
@@ -117,7 +117,7 @@ _collect_claude_pane() {
   # v2 namespace: <sidecar_dir>/<socket-hash>/<session>/<pane>.json (#109)
   local sidecar_path="${sidecar_dir}/${socket_hash}/${session}/${pane_file}.json"
 
-  local model="Claude" status="idle" task="-" activity=""
+  local model="unknown" status="idle" task="-" activity=""
   local tok_used=0 tok_total=0 tok_pct=0 tok_source="unknown" tok_fresh=true
 
   if [[ -f "$sidecar_path" ]]; then
@@ -127,7 +127,7 @@ _collect_claude_pane() {
     # Includes tokens_updated_at for independent token freshness tracking (#74).
     local raw
     raw=$(jq -r '[
-      (.model // "Claude"),
+      (.model // "unknown"),
       (.status // "idle"),
       (.tokens.pct // 0 | tostring),
       (.tokens.used // 0 | tostring),

--- a/tools/agent-tracker/setup.sh
+++ b/tools/agent-tracker/setup.sh
@@ -155,6 +155,18 @@ printf 'Restart Claude Code sessions for hooks to take effect.\n'
 REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 SIDECAR_DIR="$REPO_ROOT/.workspace/agent-tracker"
 mkdir -p "$SIDECAR_DIR"
-printf 'Sidecar directory: %s\n' "$SIDECAR_DIR"
+printf 'Sidecar directory (v2 namespace): %s/{socket-hash}/{session}/{pane}.json\n' "$SIDECAR_DIR"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Migrate: remove v1 flat sidecar files (*.json directly under sidecar dir)
+# v2 uses subdirs, so flat files are stale remnants from the old schema
+# ─────────────────────────────────────────────────────────────────────────────
+v1_files=("$SIDECAR_DIR"/*.json)
+if [[ -f "${v1_files[0]:-}" ]]; then
+  printf 'Removing v1 flat sidecar files...\n'
+  for f in "${v1_files[@]}"; do
+    [[ -f "$f" ]] && rm -f "$f" && printf '  removed: %s\n' "$(basename "$f")"
+  done
+fi
 
 printf '\nDone.\n'

--- a/tools/agent-tracker/statusline-wrapper.sh
+++ b/tools/agent-tracker/statusline-wrapper.sh
@@ -52,6 +52,10 @@ if [[ -n "$_tp" && -f "$_tp" ]]; then
     map(.message.content |
       if type == "string" then .
       else [.[] | select(.type == "text") | .text] | join(" ") end |
+      gsub("\\u001b\\[[0-9;?]*[A-Za-z]"; "") |
+      gsub("\\u001b][^\u0007]*\u0007"; "") |
+      gsub("\\u001b."; "") |
+      gsub("[[:cntrl:]]"; "") |
       gsub("\n"; " ") | gsub("  +"; " ")) |
     map(select(is_unhelpful | not)) |
     first // ""


### PR DESCRIPTION
## PR 제목

feat: writer contract alignment (#110)

## Summary

Closes #110

Aligns the agent-tracker writer (hooks/on-statusline.sh, hooks/on-status.sh) and reader (lib/collect.sh) contracts with the sidecar v2 schema. Fixes model reliability, token timestamp accuracy, control char sanitization, and pipeline state type consistency.

## Changes

| File | Change |
|------|--------|
| `tools/agent-tracker/hooks/on-status.sh` | Add ANSI CSI + OSC sequence stripping before `[[:cntrl:]]` removal in task and key_arg sanitization |
| `tools/agent-tracker/hooks/on-statusline.sh` | Preserve existing model when input has no model data; fall back to `"unknown"` instead of `"Claude"`; write `tokens_updated_at` only when `used_tokens > 0` |
| `tools/agent-tracker/statusline-wrapper.sh` | Add ANSI/OSC sanitization to `TRANSCRIPT_LAST_MSG` jq pipeline |
| `tools/agent-tracker/lib/collect.sh` | Change model reader fallback from `"Claude"` to `"unknown"` |
| `tools/agent-tracker/setup.sh` | Show v2 namespace path in output; migrate v1 flat sidecar files on run |
| `.agents/skills/dev-pipeline/scripts/dev_pipeline/models.py` | Normalize pipeline state `issue` field to `int` on load to fix string/number inconsistency from old bash-written state files |

## Type

- [x] feat — New feature

## Checklist

### 작성자 확인 (Author)

- [x] 코드가 정상 동작하는 것을 로컬에서 확인했습니다
- [ ] 관련 테스트를 추가하거나 수정했습니다
- [x] 불필요한 console.log / 디버깅 코드를 제거했습니다

### Reviewer

- [ ] Changes match the PR description
- [ ] Edge cases are handled appropriately
- [ ] No security issues found

## Notes

- `session_name` and `tmux_server` were already added to the sidecar in PR #175 (issue #109); this PR addresses the remaining alignment items.
- The `tokens_updated_at` change means sidecars without token data will preserve the last recorded timestamp (or have no timestamp), making token freshness checks accurate.
- ANSI sanitization uses three passes: CSI sequences (`ESC[...X`), OSC sequences (`ESC]...BEL`), then remaining single-char ESC sequences, before the existing `[[:cntrl:]]` strip.
