### PR TITLE
docs: archive progress records (server CI, API prefix removal, client issues 286-310, auth contract)

### DIFF
--- a/docs/client/progress.index.md
+++ b/docs/client/progress.index.md
@@ -6,6 +6,7 @@
 
 | 날짜       | 주요 작업                            | 상태 |
 | ---------- | ------------------------------------ | ---- |
+| 2026-04-10 | #297 Admin routes must not render public header - 전역 provider에서 public `Header`를 제거해 `/manage`에서는 admin shell만 렌더링되도록 정리하고 PR #302 머지 | ✅   |
 | 2026-04-10 | #295 Public shell height and spacing - public 레이아웃을 `min-h-screen` flex column으로 재구성해 짧은 페이지에서도 footer가 viewport 하단에 고정되도록 하고 자동 리뷰 2라운드 반영 후 PR #300 머지 | ✅   |
 | 2026-04-10 | #296 Admin login screen simplification - `/manage/login`을 단색 배경의 중앙 정렬 로그인 폼으로 단순화하고 PR #301 머지 | ✅   |
 | 2026-04-07 | #289 Admin auth client username 계약 전환 - admin login 응답 unwrap과 admin current-user 타입을 서버 shape에 맞추고, 사용자명 입력 UX를 정리한 뒤 자동 리뷰 2라운드 반영 후 PR #294 머지 | ✅   |
@@ -86,6 +87,7 @@
 
 ## 🔗 상세 문서
 
+- [progress.2026-04-10.md](./progress/progress.2026-04-10.md) - #297 Admin routes must not render public header PR #302 머지
 - [progress.2026-04-10.md](./progress/progress.2026-04-10.md) - #296 Admin login screen simplification PR #301 머지
 - [progress.2026-04-07.md](./progress/progress.2026-04-07.md) - #289 Admin auth client username 계약 전환 PR #294 머지
 - [progress.2026-04-07.md](./progress/progress.2026-04-07.md) - #287 Admin 방명록 hide/restore HTTP method 불일치 수정 PR #291 머지

--- a/docs/client/progress.index.md
+++ b/docs/client/progress.index.md
@@ -6,6 +6,7 @@
 
 | 날짜       | 주요 작업                            | 상태 |
 | ---------- | ------------------------------------ | ---- |
+| 2026-04-10 | #298 Category empty state must keep management controls - 카테고리 empty state에서도 관리 toolbar를 유지하고, 자동 리뷰 suggestion을 반영해 빈 상태에서는 일괄 선택/배치 편집 액션을 숨긴 뒤 PR #303 머지 | ✅   |
 | 2026-04-10 | #297 Admin routes must not render public header - 전역 provider에서 public `Header`를 제거해 `/manage`에서는 admin shell만 렌더링되도록 정리하고 PR #302 머지 | ✅   |
 | 2026-04-10 | #295 Public shell height and spacing - public 레이아웃을 `min-h-screen` flex column으로 재구성해 짧은 페이지에서도 footer가 viewport 하단에 고정되도록 하고 자동 리뷰 2라운드 반영 후 PR #300 머지 | ✅   |
 | 2026-04-10 | #296 Admin login screen simplification - `/manage/login`을 단색 배경의 중앙 정렬 로그인 폼으로 단순화하고 PR #301 머지 | ✅   |
@@ -87,6 +88,7 @@
 
 ## 🔗 상세 문서
 
+- [progress.2026-04-10.md](./progress/progress.2026-04-10.md) - #298 Category empty state must keep management controls PR #303 머지
 - [progress.2026-04-10.md](./progress/progress.2026-04-10.md) - #297 Admin routes must not render public header PR #302 머지
 - [progress.2026-04-10.md](./progress/progress.2026-04-10.md) - #296 Admin login screen simplification PR #301 머지
 - [progress.2026-04-07.md](./progress/progress.2026-04-07.md) - #289 Admin auth client username 계약 전환 PR #294 머지

--- a/docs/client/progress.index.md
+++ b/docs/client/progress.index.md
@@ -6,6 +6,7 @@
 
 | 날짜       | 주요 작업                            | 상태 |
 | ---------- | ------------------------------------ | ---- |
+| 2026-04-18 | #310 Client API 경로에서 `/api` prefix 제거 - client API helper, middleware auth 체크, Storybook/MSW 경로를 루트 기준으로 정렬하고 PR #311 머지 | ✅   |
 | 2026-04-10 | #299 Dev asset URL normalization and CSP split - `/uploads/...` 표시용 정규화, post/editor/asset copy canonical 경로 유지, dev CSP 허용 분리, 자동 리뷰 5라운드 반영 후 PR #304 머지 | ✅   |
 | 2026-04-10 | #298 Category empty state must keep management controls - 카테고리 empty state에서도 관리 toolbar를 유지하고, 자동 리뷰 suggestion을 반영해 빈 상태에서는 일괄 선택/배치 편집 액션을 숨긴 뒤 PR #303 머지 | ✅   |
 | 2026-04-10 | #297 Admin routes must not render public header - 전역 provider에서 public `Header`를 제거해 `/manage`에서는 admin shell만 렌더링되도록 정리하고 PR #302 머지 | ✅   |

--- a/docs/client/progress.index.md
+++ b/docs/client/progress.index.md
@@ -6,6 +6,7 @@
 
 | 날짜       | 주요 작업                            | 상태 |
 | ---------- | ------------------------------------ | ---- |
+| 2026-04-10 | #296 Admin login screen simplification - `/manage/login`을 단색 배경의 중앙 정렬 로그인 폼으로 단순화하고 PR #301 머지 | ✅   |
 | 2026-04-07 | #289 Admin auth client username 계약 전환 - admin login 응답 unwrap과 admin current-user 타입을 서버 shape에 맞추고, 사용자명 입력 UX를 정리한 뒤 자동 리뷰 2라운드 반영 후 PR #294 머지 | ✅   |
 | 2026-04-07 | #287 Admin 방명록 hide/restore HTTP method 불일치 수정 - guestbook patch helper를 분리해 hide/restore 단건/벌크 요청을 `PATCH`로 정리하고 PR #291 머지 | ✅   |
 | 2026-04-06 | #286 Admin 로그아웃 CSRF 계약 불일치 수정 - `logout()`을 CSRF-aware mutation helper로 전환해 PR #290 머지 | ✅   |
@@ -84,6 +85,7 @@
 
 ## 🔗 상세 문서
 
+- [progress.2026-04-10.md](./progress/progress.2026-04-10.md) - #296 Admin login screen simplification PR #301 머지
 - [progress.2026-04-07.md](./progress/progress.2026-04-07.md) - #289 Admin auth client username 계약 전환 PR #294 머지
 - [progress.2026-04-07.md](./progress/progress.2026-04-07.md) - #287 Admin 방명록 hide/restore HTTP method 불일치 수정 PR #291 머지
 - [progress.2026-04-06.md](./progress/progress.2026-04-06.md) - #286 Admin 로그아웃 CSRF 계약 불일치 수정 PR #290 머지

--- a/docs/client/progress.index.md
+++ b/docs/client/progress.index.md
@@ -6,6 +6,7 @@
 
 | 날짜       | 주요 작업                            | 상태 |
 | ---------- | ------------------------------------ | ---- |
+| 2026-04-10 | #295 Public shell height and spacing - public 레이아웃을 `min-h-screen` flex column으로 재구성해 짧은 페이지에서도 footer가 viewport 하단에 고정되도록 하고 자동 리뷰 2라운드 반영 후 PR #300 머지 | ✅   |
 | 2026-04-10 | #296 Admin login screen simplification - `/manage/login`을 단색 배경의 중앙 정렬 로그인 폼으로 단순화하고 PR #301 머지 | ✅   |
 | 2026-04-07 | #289 Admin auth client username 계약 전환 - admin login 응답 unwrap과 admin current-user 타입을 서버 shape에 맞추고, 사용자명 입력 UX를 정리한 뒤 자동 리뷰 2라운드 반영 후 PR #294 머지 | ✅   |
 | 2026-04-07 | #287 Admin 방명록 hide/restore HTTP method 불일치 수정 - guestbook patch helper를 분리해 hide/restore 단건/벌크 요청을 `PATCH`로 정리하고 PR #291 머지 | ✅   |

--- a/docs/client/progress.index.md
+++ b/docs/client/progress.index.md
@@ -6,6 +6,7 @@
 
 | 날짜       | 주요 작업                            | 상태 |
 | ---------- | ------------------------------------ | ---- |
+| 2026-04-07 | #289 Admin auth client username 계약 전환 - admin login 응답 unwrap과 admin current-user 타입을 서버 shape에 맞추고, 사용자명 입력 UX를 정리한 뒤 자동 리뷰 2라운드 반영 후 PR #294 머지 | ✅   |
 | 2026-04-07 | #287 Admin 방명록 hide/restore HTTP method 불일치 수정 - guestbook patch helper를 분리해 hide/restore 단건/벌크 요청을 `PATCH`로 정리하고 PR #291 머지 | ✅   |
 | 2026-04-06 | #286 Admin 로그아웃 CSRF 계약 불일치 수정 - `logout()`을 CSRF-aware mutation helper로 전환해 PR #290 머지 | ✅   |
 | 2026-04-04 | #281 Admin 댓글 상태 전환 UI를 실제 API와 연결 - 상세 모달 상태 칩을 hide/restore/delete API와 연결, 관리자 댓글 목록/dashboard 최근 댓글 동기화, 자동 리뷰 4라운드 반영 후 PR #285 머지 | ✅   |
@@ -83,6 +84,7 @@
 
 ## 🔗 상세 문서
 
+- [progress.2026-04-07.md](./progress/progress.2026-04-07.md) - #289 Admin auth client username 계약 전환 PR #294 머지
 - [progress.2026-04-07.md](./progress/progress.2026-04-07.md) - #287 Admin 방명록 hide/restore HTTP method 불일치 수정 PR #291 머지
 - [progress.2026-04-06.md](./progress/progress.2026-04-06.md) - #286 Admin 로그아웃 CSRF 계약 불일치 수정 PR #290 머지
 - [progress.2026-04-04.md](./progress/progress.2026-04-04.md) - #281 Admin 댓글 상태 전환 UI를 실제 API와 연결 PR #285 머지

--- a/docs/client/progress.index.md
+++ b/docs/client/progress.index.md
@@ -6,6 +6,7 @@
 
 | 날짜       | 주요 작업                            | 상태 |
 | ---------- | ------------------------------------ | ---- |
+| 2026-04-06 | #286 Admin 로그아웃 CSRF 계약 불일치 수정 - `logout()`을 CSRF-aware mutation helper로 전환해 PR #290 머지 | ✅   |
 | 2026-04-04 | #281 Admin 댓글 상태 전환 UI를 실제 API와 연결 - 상세 모달 상태 칩을 hide/restore/delete API와 연결, 관리자 댓글 목록/dashboard 최근 댓글 동기화, 자동 리뷰 4라운드 반영 후 PR #285 머지 | ✅   |
 | 2026-03-29 | #260 PostListItem 디자인 리뉴얼 - 와이어프레임 `post-item` 구조, 모바일 썸네일, category shimmer, pin float, Solar 메타 아이콘 적용 후 PR #261 머지 | ✅   |
 | 2026-03-28 | #205 글 관리 인라인 토글 + 영구 삭제 (F-21c) - 수정일 컬럼/미리보기 Storybook 정리, server pinned-count endpoint 연동, 자동 리뷰 4라운드 반영 후 PR #259 머지 | ✅   |
@@ -81,6 +82,7 @@
 
 ## 🔗 상세 문서
 
+- [progress.2026-04-06.md](./progress/progress.2026-04-06.md) - #286 Admin 로그아웃 CSRF 계약 불일치 수정 PR #290 머지
 - [progress.2026-04-04.md](./progress/progress.2026-04-04.md) - #281 Admin 댓글 상태 전환 UI를 실제 API와 연결 PR #285 머지
 - [progress.2026-03-29.md](./progress/progress.2026-03-29.md) - #260 PostListItem 디자인 리뉴얼 PR #261 머지
 - [progress.2026-03-28.md](./progress/progress.2026-03-28.md) - #205 글 관리 인라인 토글 + 영구 삭제 (F-21c) PR #259 머지

--- a/docs/client/progress.index.md
+++ b/docs/client/progress.index.md
@@ -6,6 +6,7 @@
 
 | 날짜       | 주요 작업                            | 상태 |
 | ---------- | ------------------------------------ | ---- |
+| 2026-04-10 | #299 Dev asset URL normalization and CSP split - `/uploads/...` 표시용 정규화, post/editor/asset copy canonical 경로 유지, dev CSP 허용 분리, 자동 리뷰 5라운드 반영 후 PR #304 머지 | ✅   |
 | 2026-04-10 | #298 Category empty state must keep management controls - 카테고리 empty state에서도 관리 toolbar를 유지하고, 자동 리뷰 suggestion을 반영해 빈 상태에서는 일괄 선택/배치 편집 액션을 숨긴 뒤 PR #303 머지 | ✅   |
 | 2026-04-10 | #297 Admin routes must not render public header - 전역 provider에서 public `Header`를 제거해 `/manage`에서는 admin shell만 렌더링되도록 정리하고 PR #302 머지 | ✅   |
 | 2026-04-10 | #295 Public shell height and spacing - public 레이아웃을 `min-h-screen` flex column으로 재구성해 짧은 페이지에서도 footer가 viewport 하단에 고정되도록 하고 자동 리뷰 2라운드 반영 후 PR #300 머지 | ✅   |
@@ -88,6 +89,7 @@
 
 ## 🔗 상세 문서
 
+- [progress.2026-04-10.md](./progress/progress.2026-04-10.md) - #299 Dev asset URL normalization and CSP split PR #304 머지
 - [progress.2026-04-10.md](./progress/progress.2026-04-10.md) - #298 Category empty state must keep management controls PR #303 머지
 - [progress.2026-04-10.md](./progress/progress.2026-04-10.md) - #297 Admin routes must not render public header PR #302 머지
 - [progress.2026-04-10.md](./progress/progress.2026-04-10.md) - #296 Admin login screen simplification PR #301 머지

--- a/docs/client/progress.index.md
+++ b/docs/client/progress.index.md
@@ -6,6 +6,7 @@
 
 | 날짜       | 주요 작업                            | 상태 |
 | ---------- | ------------------------------------ | ---- |
+| 2026-04-07 | #287 Admin 방명록 hide/restore HTTP method 불일치 수정 - guestbook patch helper를 분리해 hide/restore 단건/벌크 요청을 `PATCH`로 정리하고 PR #291 머지 | ✅   |
 | 2026-04-06 | #286 Admin 로그아웃 CSRF 계약 불일치 수정 - `logout()`을 CSRF-aware mutation helper로 전환해 PR #290 머지 | ✅   |
 | 2026-04-04 | #281 Admin 댓글 상태 전환 UI를 실제 API와 연결 - 상세 모달 상태 칩을 hide/restore/delete API와 연결, 관리자 댓글 목록/dashboard 최근 댓글 동기화, 자동 리뷰 4라운드 반영 후 PR #285 머지 | ✅   |
 | 2026-03-29 | #260 PostListItem 디자인 리뉴얼 - 와이어프레임 `post-item` 구조, 모바일 썸네일, category shimmer, pin float, Solar 메타 아이콘 적용 후 PR #261 머지 | ✅   |
@@ -82,6 +83,7 @@
 
 ## 🔗 상세 문서
 
+- [progress.2026-04-07.md](./progress/progress.2026-04-07.md) - #287 Admin 방명록 hide/restore HTTP method 불일치 수정 PR #291 머지
 - [progress.2026-04-06.md](./progress/progress.2026-04-06.md) - #286 Admin 로그아웃 CSRF 계약 불일치 수정 PR #290 머지
 - [progress.2026-04-04.md](./progress/progress.2026-04-04.md) - #281 Admin 댓글 상태 전환 UI를 실제 API와 연결 PR #285 머지
 - [progress.2026-03-29.md](./progress/progress.2026-03-29.md) - #260 PostListItem 디자인 리뉴얼 PR #261 머지

--- a/docs/client/progress/progress.2026-04-06.md
+++ b/docs/client/progress/progress.2026-04-06.md
@@ -1,0 +1,25 @@
+# Client Progress - 2026-04-06
+
+## 완료된 작업
+
+### #286 Admin 로그아웃 CSRF 계약 불일치 수정 (PR #290 머지)
+
+관리자 로그아웃 helper가 CSRF 토큰 없이 `POST /api/auth/admin/logout`를 호출하던 경로를 서버 계약에 맞게 정리했다. `logout()`을 일반 fetch 경로에서 CSRF-aware mutation helper로 바꿔 기존 UI 호출부는 그대로 유지하면서 요청 헤더에 CSRF 토큰이 포함되도록 수정했고, 자동 리뷰 clean 상태까지 확인한 뒤 PR을 병합했다.
+
+**주요 변경 사항:**
+
+- `src/entities/auth/api.ts`
+  - `logout()`이 `clientFetch` 직접 호출 대신 `clientMutate`를 사용하도록 변경
+  - 관리자 로그아웃 POST 요청이 shared CSRF 토큰 주입 경로를 타도록 정리
+
+**검증:**
+
+- `pnpm install --frozen-lockfile`
+- `pnpm compile:types`
+- `pnpm lint`
+- `pnpm build`
+
+**메모:**
+
+- `pnpm lint`는 저장소 기존 warning인 `src/features/post-editor/ui/image-gallery-modal.tsx`의 `<img>` 사용 1건과 `src/shared/ui/error-boundary.tsx`의 `_error` 미사용 1건만 남았다.
+- PR `#290`은 동기 `codex` 리뷰에서 clean 판정 후 바로 병합됐다.

--- a/docs/client/progress/progress.2026-04-07.md
+++ b/docs/client/progress/progress.2026-04-07.md
@@ -1,0 +1,26 @@
+# Client Progress - 2026-04-07
+
+## 완료된 작업
+
+### #287 Admin 방명록 hide/restore HTTP method 불일치 수정 (PR #291 머지)
+
+관리자 방명록 `hide/restore` helper가 삭제 helper를 재사용하면서 `DELETE`로 요청하던 문제를 서버 계약에 맞게 정리했다. `guestbook` entity API에서 삭제 계열과 상태 전환 계열 helper의 책임을 분리해 단건/벌크 `hide` 및 `restore` 요청이 모두 `PATCH`를 사용하도록 수정했고, 동기 `codex` 리뷰 clean 상태까지 확인한 뒤 PR을 병합했다.
+
+**주요 변경 사항:**
+
+- `src/entities/guestbook/api.ts`
+  - `adminPatchGuestbookEntry()`가 삭제 helper 위임 대신 `PATCH /api/admin/guestbook/:id?action=...`를 직접 호출하도록 수정
+  - `adminBulkPatchGuestbookEntries()`가 `PATCH /api/admin/guestbook/bulk`를 사용하도록 수정
+  - 삭제 helper는 `soft_delete`/`hard_delete` 액션만 받도록 타입을 좁혀 patch/delete 의미를 분리
+
+**검증:**
+
+- `pnpm compile:types`
+- `pnpm lint`
+- `pnpm build`
+
+**메모:**
+
+- `pnpm lint`는 저장소 기존 warning인 `src/features/post-editor/ui/image-gallery-modal.tsx`의 `<img>` 사용 1건과 `src/shared/ui/error-boundary.tsx`의 `_error` 미사용 1건만 남았다.
+- `pnpm build`는 이번 변경과 무관하게 원본 `client` 저장소와 issue worktree 모두에서 `lightningcss.linux-arm64-gnu.node` 누락으로 실패했다.
+- PR `#291`은 동기 `codex` 리뷰에서 clean 판정 후 바로 병합됐다.

--- a/docs/client/progress/progress.2026-04-07.md
+++ b/docs/client/progress/progress.2026-04-07.md
@@ -2,6 +2,34 @@
 
 ## 완료된 작업
 
+### #289 Admin auth client username 계약 전환 (PR #294 머지)
+
+관리자 로그인 클라이언트를 현재 서버 응답 구조에 맞게 정리했다. `auth` entity의 admin 타입에서 legacy `displayName`을 제거하고 `POST /api/auth/admin/login` 응답을 `{ admin }` 래퍼에서 안전하게 unwrap하도록 수정했다. 로그인 폼에서는 `username` 값을 trim 없이 그대로 전송하도록 바꾸고, 라벨/placeholder/helper copy를 이메일이 아닌 사용자명 기준으로 정리했다. 1차 자동 리뷰에서 클라이언트가 서버보다 더 엄격한 username 제약과 `autocomplete="off"`를 도입한 점이 경고로 잡혀, 브라우저 단의 과도한 길이/pattern 제한을 제거하고 `autoComplete="username"`을 복원한 뒤 재리뷰 clean 상태로 PR을 병합했다.
+
+**주요 변경 사항:**
+
+- `src/entities/auth/model.ts`
+  - admin 로그인 응답 타입을 `id/username/createdAt/updatedAt/lastLoginAt` 구조로 정리
+  - legacy `displayName` 필드를 제거하고 `/api/auth/me`의 admin shape와 일치시킴
+- `src/entities/auth/api.ts`
+  - `clientFetch<{ admin: AdminUser }>()`로 로그인 응답을 받고 `response.admin`을 반환하도록 수정
+- `src/features/admin-login/ui/login-form.tsx`
+  - `username.trim()` 제거로 입력값을 그대로 전송
+  - 라벨/placeholder/helper를 사용자명 기준으로 정리
+  - `autoComplete="username"` 유지, `autoCapitalize="none"`/`autoCorrect="off"`/`spellCheck={false}` 적용
+
+**검증:**
+
+- `pnpm compile:types`
+- `pnpm lint`
+- `pnpm build` *(환경 이슈로 실패)*
+
+**메모:**
+
+- `pnpm lint`는 저장소 기존 warning인 `src/features/post-editor/ui/image-gallery-modal.tsx`의 `<img>` 사용 1건과 `src/shared/ui/error-boundary.tsx`의 `_error` 미사용 1건만 남았다.
+- `pnpm build`는 이번 변경과 무관하게 원본 `client` 저장소와 issue worktree 모두에서 `lightningcss.linux-arm64-gnu.node` 누락으로 실패했다.
+- PR `#294`는 동기 `codex` 리뷰 2라운드 후 clean 판정으로 병합됐다.
+
 ### #287 Admin 방명록 hide/restore HTTP method 불일치 수정 (PR #291 머지)
 
 관리자 방명록 `hide/restore` helper가 삭제 helper를 재사용하면서 `DELETE`로 요청하던 문제를 서버 계약에 맞게 정리했다. `guestbook` entity API에서 삭제 계열과 상태 전환 계열 helper의 책임을 분리해 단건/벌크 `hide` 및 `restore` 요청이 모두 `PATCH`를 사용하도록 수정했고, 동기 `codex` 리뷰 clean 상태까지 확인한 뒤 PR을 병합했다.

--- a/docs/client/progress/progress.2026-04-10.md
+++ b/docs/client/progress/progress.2026-04-10.md
@@ -1,0 +1,28 @@
+# Client Progress - 2026-04-10
+
+## 완료된 작업
+
+### #296 Admin login screen simplification (PR #301 머지)
+
+`/manage/login` 화면을 로그인 폼에만 집중하는 구조로 단순화했다. 로그인 전용 layout에서 상단/하단 radial gradient 장식과 넓은 콘텐츠 래퍼를 제거하고, 페이지에서 소개용 카피 섹션을 없애 `main > form` 구조만 남겼다. 로그인 폼은 `bg-background-1` 단색 배경 위에서 화면 정중앙에 배치되도록 재구성했고, 헤더 카피도 대시보드 진입 목적만 전달하도록 간결하게 정리했다. 동기 `codex` 리뷰 clean 상태를 확인한 뒤 PR을 병합했다.
+
+**주요 변경 사항:**
+
+- `src/app/manage/login/layout.tsx`
+  - 로그인 전용 배경 장식 레이어와 max-width 래퍼를 제거하고 단색 배경만 유지
+- `src/app/manage/login/page.tsx`
+  - 소개 섹션을 제거하고 로그인 폼만 렌더링하도록 단순화
+- `src/features/admin-login/ui/login-form.tsx`
+  - 폼을 `min-h-screen` 중앙 정렬 레이아웃으로 변경
+  - 로그인 안내 카피를 간결하게 조정
+
+**검증:**
+
+- `pnpm compile:types`
+- `pnpm lint` *(저장소 기존 warning 2건 유지)*
+- `pnpm build`
+
+**메모:**
+
+- `pnpm lint`는 저장소 기존 warning인 `src/features/post-editor/ui/image-gallery-modal.tsx`의 `<img>` 사용 1건과 `src/shared/ui/error-boundary.tsx`의 `_error` 미사용 1건만 남았다.
+- PR `#301`은 동기 `codex` 리뷰 clean 판정 후 바로 병합됐다.

--- a/docs/client/progress/progress.2026-04-10.md
+++ b/docs/client/progress/progress.2026-04-10.md
@@ -2,6 +2,26 @@
 
 ## 완료된 작업
 
+### #297 Admin routes must not render public header (PR #302 머지)
+
+관리자 라우트가 전역 provider에서 주입되는 public `Header`와 admin shell header를 동시에 렌더링하던 문제를 수정했다. public header는 이미 `src/app/(public)/layout-shell.tsx`가 소유하고 있으므로, `src/app-layer/provider/index.tsx`에서 전역 `Header` 렌더링을 제거해 `/manage` 이하에서는 admin chrome만 남도록 정리했다. 동기 `codex` 리뷰 clean 상태를 확인한 뒤 PR을 병합했다.
+
+**주요 변경 사항:**
+
+- `src/app-layer/provider/index.tsx`
+  - 전역 provider에서 public `Header`를 제거해 route별 layout shell이 각자 chrome을 책임지도록 정리
+
+**검증:**
+
+- `pnpm compile:types`
+- `pnpm lint` *(저장소 기존 warning 2건 유지)*
+- `pnpm build` *(저장소 환경 이슈로 실패: `lightningcss.linux-arm64-gnu.node` 누락, `/workspace/client` 의존성 트리에서 재현)*
+
+**메모:**
+
+- `pnpm lint`는 저장소 기존 warning인 `src/features/post-editor/ui/image-gallery-modal.tsx`의 `<img>` 사용 1건과 `src/shared/ui/error-boundary.tsx`의 `_error` 미사용 1건만 남았다.
+- PR `#302`는 동기 `codex` 리뷰 clean 판정 후 바로 병합됐다.
+
 ### #295 Public shell height and spacing (PR #300 머지)
 
 Public 레이아웃이 viewport 높이를 채우지 못해 콘텐츠가 짧을 때 footer가 본문 바로 아래로 올라오던 문제를 수정했다. `src/app/(public)/layout.tsx`에서 public 트리를 `min-h-screen` 기반의 세로 flex column으로 감싸고, `src/app/(public)/layout-shell.tsx`는 헤더 아래의 콘텐츠 셸이 남은 높이를 차지하도록 `flex-1` 구조로 재구성했다. 1차 자동 리뷰에서 layout-level `<main>`이 기존 route page들의 `<main>`과 중첩된다는 경고가 나와 neutral wrapper로 되돌린 뒤 2차 `codex` 리뷰 clean 상태를 확인하고 PR을 병합했다.

--- a/docs/client/progress/progress.2026-04-10.md
+++ b/docs/client/progress/progress.2026-04-10.md
@@ -2,6 +2,37 @@
 
 ## 완료된 작업
 
+### #299 Dev asset URL normalization and CSP split (PR #304 머지)
+
+개발 환경에서 업로드 자산이 `/uploads/...` 상대 경로로 내려올 때 Next.js origin 기준으로 해석되어 이미지가 깨지고, CSP report-only 위반이 Google Fonts/개발 런타임 경고로 과하게 오염되던 문제를 정리했다. `NEXT_PUBLIC_API_URL`이 설정된 경우에만 `/uploads/...`를 표시용 절대 URL로 정규화하는 shared helper를 추가하고, post thumbnail/markdown/admin asset 미리보기는 이 helper를 렌더링 경계에서만 사용하도록 조정했다. 반대로 업로드 응답, editor 저장 payload, asset copy/markdown copy처럼 persisted data로 흘러가는 경로는 canonical `/uploads/...`를 유지하도록 여러 차례 리뷰 코멘트를 반영했다. `src/middleware.ts`는 dev/prod CSP를 분기해 development에서 필요한 `fonts.googleapis.com`, `unsafe-eval`, websocket connect 예외만 제한적으로 허용하도록 수정한 뒤 PR을 병합했다.
+
+**주요 변경 사항:**
+
+- `src/shared/lib/asset-url.ts`
+  - `/uploads/...` 경로를 표시용으로만 정규화하는 helper와 절대 URL을 canonical 경로로 되돌리는 helper를 추가
+  - `NEXT_PUBLIC_API_URL`이 없으면 localhost fallback을 만들지 않고 상대 경로를 그대로 유지하도록 보완
+- `src/entities/post/api.ts`, `src/shared/lib/markdown.ts`
+  - post thumbnail read 경로와 markdown 렌더링에서만 asset URL을 정규화해 기존 relative asset도 public/admin 화면에서 정상 렌더링되도록 조정
+- `src/features/post-editor/ui/*`
+  - thumbnail picker/upload, post preview, submit payload에서 display URL과 persisted URL을 분리
+  - 저장 시 `thumbnailUrl`은 다시 canonical `/uploads/...`로 변환해 no-op edit에도 절대 URL이 저장되지 않도록 수정
+- `src/entities/asset/lib.ts`, `src/features/asset-uploader/ui/asset-uploader.tsx`
+  - asset manager의 URL/markdown copy 흐름에서 environment-specific absolute URL이 클립보드로 유출되지 않도록 canonicalization 추가
+- `src/middleware.ts`
+  - dev/prod CSP를 분리하고 development에 필요한 font/style/script/connect 예외만 허용
+
+**검증:**
+
+- `pnpm build`
+- `pnpm compile:types` *(build 후 `.next/types` 생성 상태에서 재실행)*
+- `pnpm lint` *(저장소 기존 warning 2건 유지)*
+
+**메모:**
+
+- 검증을 위해 issue worktree에서 `pnpm install --frozen-lockfile`로 로컬 `node_modules`를 구성했다.
+- `pnpm lint`는 저장소 기존 warning인 `src/features/post-editor/ui/image-gallery-modal.tsx`의 `<img>` 사용 1건과 `src/shared/ui/error-boundary.tsx`의 `_error` 미사용 1건만 남았다.
+- PR `#304`는 동기 `codex` 리뷰 5라운드 동안 canonical/presentation 경계를 순차 보정한 뒤 clean 판정으로 병합됐다.
+
 ### #298 Category empty state must keep management controls (PR #303 머지)
 
 카테고리 관리 페이지에서 카테고리가 0개일 때도 control box 역할의 toolbar가 계속 노출되도록 empty state 렌더링 경로를 조정했다. `src/features/category-manager/ui/category-tree.tsx`의 조기 반환을 제거하고 toolbar를 상단에 유지한 뒤, empty state는 본문 카드 안에서만 렌더링되도록 분리했다. 1차 동기 `codex` 리뷰 suggestion에서 빈 상태에 일괄 선택/배치 편집 액션이 노출되는 UX 회귀가 지적돼, `src/features/category-manager/ui/category-tree-toolbar.tsx`에서 카테고리 수가 0개일 때 해당 액션을 숨기고 생성 버튼과 표시 토글만 남기도록 보완한 후 재리뷰 clean 상태로 PR을 병합했다.

--- a/docs/client/progress/progress.2026-04-10.md
+++ b/docs/client/progress/progress.2026-04-10.md
@@ -2,6 +2,29 @@
 
 ## 완료된 작업
 
+### #295 Public shell height and spacing (PR #300 머지)
+
+Public 레이아웃이 viewport 높이를 채우지 못해 콘텐츠가 짧을 때 footer가 본문 바로 아래로 올라오던 문제를 수정했다. `src/app/(public)/layout.tsx`에서 public 트리를 `min-h-screen` 기반의 세로 flex column으로 감싸고, `src/app/(public)/layout-shell.tsx`는 헤더 아래의 콘텐츠 셸이 남은 높이를 차지하도록 `flex-1` 구조로 재구성했다. 1차 자동 리뷰에서 layout-level `<main>`이 기존 route page들의 `<main>`과 중첩된다는 경고가 나와 neutral wrapper로 되돌린 뒤 2차 `codex` 리뷰 clean 상태를 확인하고 PR을 병합했다.
+
+**주요 변경 사항:**
+
+- `src/app/(public)/layout.tsx`
+  - public 페이지 전체를 `min-h-screen flex flex-col` 래퍼로 감싸 footer가 viewport 하단까지 밀리도록 조정
+- `src/app/(public)/layout-shell.tsx`
+  - shell 루트를 `flex flex-1 flex-col`로 바꾸고, 헤더 아래 2-column 콘텐츠 영역이 남은 높이를 점유하도록 수정
+  - route page별 landmark 구조를 보존하기 위해 콘텐츠 래퍼는 `<main>` 대신 neutral `<div>`로 유지
+
+**검증:**
+
+- `pnpm compile:types`
+- `pnpm lint` *(저장소 기존 warning 2건 유지)*
+- `pnpm build` *(저장소 환경 이슈로 실패: `lightningcss.linux-arm64-gnu.node` 누락, `/workspace/client`에서도 동일 재현)*
+
+**메모:**
+
+- `pnpm lint`는 저장소 기존 warning인 `src/features/post-editor/ui/image-gallery-modal.tsx`의 `<img>` 사용 1건과 `src/shared/ui/error-boundary.tsx`의 `_error` 미사용 1건만 남았다.
+- PR `#300`은 동기 `codex` 리뷰 2라운드 후 clean 판정으로 병합됐다.
+
 ### #296 Admin login screen simplification (PR #301 머지)
 
 `/manage/login` 화면을 로그인 폼에만 집중하는 구조로 단순화했다. 로그인 전용 layout에서 상단/하단 radial gradient 장식과 넓은 콘텐츠 래퍼를 제거하고, 페이지에서 소개용 카피 섹션을 없애 `main > form` 구조만 남겼다. 로그인 폼은 `bg-background-1` 단색 배경 위에서 화면 정중앙에 배치되도록 재구성했고, 헤더 카피도 대시보드 진입 목적만 전달하도록 간결하게 정리했다. 동기 `codex` 리뷰 clean 상태를 확인한 뒤 PR을 병합했다.

--- a/docs/client/progress/progress.2026-04-10.md
+++ b/docs/client/progress/progress.2026-04-10.md
@@ -2,6 +2,30 @@
 
 ## 완료된 작업
 
+### #298 Category empty state must keep management controls (PR #303 머지)
+
+카테고리 관리 페이지에서 카테고리가 0개일 때도 control box 역할의 toolbar가 계속 노출되도록 empty state 렌더링 경로를 조정했다. `src/features/category-manager/ui/category-tree.tsx`의 조기 반환을 제거하고 toolbar를 상단에 유지한 뒤, empty state는 본문 카드 안에서만 렌더링되도록 분리했다. 1차 동기 `codex` 리뷰 suggestion에서 빈 상태에 일괄 선택/배치 편집 액션이 노출되는 UX 회귀가 지적돼, `src/features/category-manager/ui/category-tree-toolbar.tsx`에서 카테고리 수가 0개일 때 해당 액션을 숨기고 생성 버튼과 표시 토글만 남기도록 보완한 후 재리뷰 clean 상태로 PR을 병합했다.
+
+**주요 변경 사항:**
+
+- `src/features/category-manager/ui/category-tree.tsx`
+  - 카테고리 0개 상태에서도 toolbar를 항상 렌더링하도록 early return 제거
+  - empty state를 tree content 영역 내부 카드로 옮기고, 빈 트리에서는 drag-and-drop 컨텍스트를 마운트하지 않도록 분기
+- `src/features/category-manager/ui/category-tree-toolbar.tsx`
+  - `totalCount === 0`일 때 `일괄 선택`과 `배치 편집` 버튼을 숨기고 `카테고리 추가` 버튼은 유지
+
+**검증:**
+
+- `pnpm build`
+- `pnpm compile:types` *(build 후 `.next/types` 생성 상태에서 재실행)*
+- `pnpm lint` *(저장소 기존 warning 2건 유지)*
+
+**메모:**
+
+- 워크트리에는 의존성이 없어 검증 전에 `pnpm install --frozen-lockfile`로 로컬 `node_modules`를 구성했다.
+- `pnpm lint`는 저장소 기존 warning인 `src/features/post-editor/ui/image-gallery-modal.tsx`의 `<img>` 사용 1건과 `src/shared/ui/error-boundary.tsx`의 `_error` 미사용 1건만 남았다.
+- PR `#303`은 동기 `codex` 리뷰 2라운드 후 clean 판정으로 병합됐다.
+
 ### #297 Admin routes must not render public header (PR #302 머지)
 
 관리자 라우트가 전역 provider에서 주입되는 public `Header`와 admin shell header를 동시에 렌더링하던 문제를 수정했다. public header는 이미 `src/app/(public)/layout-shell.tsx`가 소유하고 있으므로, `src/app-layer/provider/index.tsx`에서 전역 `Header` 렌더링을 제거해 `/manage` 이하에서는 admin chrome만 남도록 정리했다. 동기 `codex` 리뷰 clean 상태를 확인한 뒤 PR을 병합했다.

--- a/docs/client/progress/progress.2026-04-18.md
+++ b/docs/client/progress/progress.2026-04-18.md
@@ -1,0 +1,30 @@
+# Client Progress - 2026-04-18
+
+## 완료된 작업
+
+### #310 Client API 경로에서 /api prefix 제거 (PR #311 머지)
+
+서버의 `/api` prefix 제거에 맞춰 client 전역의 API 호출 경로를 루트 기준 경로로 정렬했다. 공개/관리자 API helper, CSRF 토큰 조회, 조회수 기록, middleware 인증 확인, Storybook MSW handler를 함께 업데이트해 런타임 호출과 스토리북 mock이 같은 계약을 보도록 맞췄다. 자동 리뷰는 clean으로 종료됐고 PR `#311`이 병합됐다.
+
+**주요 변경 사항:**
+
+- `src/entities/{auth,asset,category,comment,guestbook,post,stat,tag}/api.ts`
+  - public/admin endpoint 경로를 `/api/...` 에서 `/...` 로 일괄 변경
+  - asset upload XHR 경로와 post/comment/guestbook/stat/auth helper를 새 서버 경로에 맞춤
+- `src/shared/api/csrf.ts`, `src/shared/hooks/use-view-count.ts`, `src/shared/hooks/use-site-view-count.ts`, `src/middleware.ts`
+  - CSRF token 조회, 조회수 mutation, middleware의 `auth/me` 인증 체크 경로를 새 계약으로 정렬
+- `stories/**/*`
+  - Storybook MSW handler와 story별 mock URL을 새 경로로 변경
+  - category/assets mock 일부를 실제 client 응답 shape에 맞게 수정
+
+**검증:**
+
+- `pnpm compile:types`
+- `pnpm lint`
+- `pnpm build` 실행 시도
+
+**메모:**
+
+- `pnpm lint`는 저장소 기존 warning인 `src/features/post-editor/ui/image-gallery-modal.tsx`의 `<img>` 사용 1건과 `src/shared/ui/error-boundary.tsx`의 `_error` 미사용 1건만 남았다.
+- `pnpm build`는 코드 오류가 아니라 현재 환경의 `lightningcss.linux-arm64-gnu.node` 네이티브 바이너리 누락으로 실패했다.
+- 자동 리뷰 결과는 Critical/Warning/Suggestion 모두 0건이었다.

--- a/docs/server/progress.index.md
+++ b/docs/server/progress.index.md
@@ -6,6 +6,7 @@
 
 | 날짜       | 주요 작업                              | 상태 |
 | ---------- | -------------------------------------- | ---- |
+| 2026-04-10 | Issue #87 API spec/test alignment baseline: auth/guestbook/settings 계약 기준 테스트 정렬, 실제 앱 CSRF e2e 검증 추가, health/stats/settings-service 불안정성 수정, 전체 스위트 `17` files / `258` tests green 복구, PR #90 머지 | ✅   |
 | 2026-04-10 | Issue #88 Dev uploads 상대 경로 계약 유지 및 정적 서빙 검증: upload dir/url prefix 공통화, static 플러그인에서 업로드 디렉토리 선생성, assets 통합 테스트에 `/uploads/...` 정적 접근 검증 추가, PR #89 머지 | ✅   |
 | 2026-04-07 | Issue #84 발행 시 summary 자동 생성: published 저장 시 `contentMd` plain text 200자 summary 보장, draft→published `publishedAt` 보강, posts 테스트 추가, PR #85 머지 | ✅   |
 | 2026-04-06 | Issue #80 Admin auth route username contract 전환: login/me 응답에서 legacy `email` 필드 제거, request body를 `username` 단일 필드로 정리, migrated email-shaped username 호환 로그인 유지, PR #83 머지 | ✅   |
@@ -61,6 +62,7 @@
 
 ## 🔗 상세 문서
 
+- [progress.2026-04-10.md](./progress/progress.2026-04-10.md) - Issue #87 API spec/test alignment baseline + PR #90 머지
 - [progress.2026-04-10.md](./progress/progress.2026-04-10.md) - Issue #88 uploads 상대 경로 계약/정적 서빙 검증 + PR #89 머지
 - [progress.2026-04-07.md](./progress/progress.2026-04-07.md) - Issue #84 발행 시 summary 자동 생성 + PR #85 머지
 - [progress.2026-04-06.md](./progress/progress.2026-04-06.md) - Issue #80 Admin auth route username contract 전환 + PR #83 머지

--- a/docs/server/progress.index.md
+++ b/docs/server/progress.index.md
@@ -6,6 +6,7 @@
 
 | 날짜       | 주요 작업                              | 상태 |
 | ---------- | -------------------------------------- | ---- |
+| 2026-04-06 | Issue #79 Category/Asset mutation route CSRF 누락 수정: categories/assets 관리자 mutation route에 명시적 CSRF hook 추가, route introspection 테스트 보강, PR #82 머지 | ✅   |
 | 2026-04-02 | Issue #75 Admin 댓글 hidden 상태 전환 API 추가: 단건/벌크 hide, public/post commentCount 가시성 정렬, hide 경로 CSRF 적용, PR #76 머지 | ✅   |
 | 2026-03-29 | Issue #73 Admin pinned 글 상한(5개) 강제: pinned count 엔드포인트 추가, create/update/restore/delete 전이 동시성 잠금 정리, posts 테스트 보강, PR #74 머지 | ✅   |
 | 2026-03-28 | Issue #69 Admin 댓글 hidden 상태 복원 API 지원: 단일/벌크 restore를 `deleted | hidden -> active`로 확장, comments 테스트 보강, 리뷰 제안으로 restore `400` 응답 스키마 보완, PR #72 머지 | ✅   |
@@ -57,6 +58,7 @@
 
 ## 🔗 상세 문서
 
+- [progress.2026-04-06.md](./progress/progress.2026-04-06.md) - Issue #79 Category/Asset mutation route CSRF 누락 수정 + PR #82 머지
 - [progress.2026-04-02.md](./progress/progress.2026-04-02.md) - Issue #75 Admin 댓글 hidden 상태 전환 API 추가 + PR #76 머지
 - [progress.2026-03-29.md](./progress/progress.2026-03-29.md) - Issue #73 Admin pinned 글 상한 5개 강제 + pinned count 엔드포인트 + PR #74 머지
 - [progress.2026-03-28.md](./progress/progress.2026-03-28.md) - Issue #69 Admin 댓글 hidden 상태 복원 API 지원 + PR #72 머지

--- a/docs/server/progress.index.md
+++ b/docs/server/progress.index.md
@@ -6,6 +6,7 @@
 
 | 날짜       | 주요 작업                              | 상태 |
 | ---------- | -------------------------------------- | ---- |
+| 2026-04-07 | Issue #84 발행 시 summary 자동 생성: published 저장 시 `contentMd` plain text 200자 summary 보장, draft→published `publishedAt` 보강, posts 테스트 추가, PR #85 머지 | ✅   |
 | 2026-04-06 | Issue #80 Admin auth route username contract 전환: login/me 응답에서 legacy `email` 필드 제거, request body를 `username` 단일 필드로 정리, migrated email-shaped username 호환 로그인 유지, PR #83 머지 | ✅   |
 | 2026-04-06 | Issue #79 Category/Asset mutation route CSRF 누락 수정: categories/assets 관리자 mutation route에 명시적 CSRF hook 추가, route introspection 테스트 보강, PR #82 머지 | ✅   |
 | 2026-04-02 | Issue #75 Admin 댓글 hidden 상태 전환 API 추가: 단건/벌크 hide, public/post commentCount 가시성 정렬, hide 경로 CSRF 적용, PR #76 머지 | ✅   |
@@ -59,6 +60,7 @@
 
 ## 🔗 상세 문서
 
+- [progress.2026-04-07.md](./progress/progress.2026-04-07.md) - Issue #84 발행 시 summary 자동 생성 + PR #85 머지
 - [progress.2026-04-06.md](./progress/progress.2026-04-06.md) - Issue #80 Admin auth route username contract 전환 + PR #83 머지
 - [progress.2026-04-06.md](./progress/progress.2026-04-06.md) - Issue #79 Category/Asset mutation route CSRF 누락 수정 + PR #82 머지
 - [progress.2026-04-02.md](./progress/progress.2026-04-02.md) - Issue #75 Admin 댓글 hidden 상태 전환 API 추가 + PR #76 머지

--- a/docs/server/progress.index.md
+++ b/docs/server/progress.index.md
@@ -6,6 +6,7 @@
 
 | 날짜       | 주요 작업                              | 상태 |
 | ---------- | -------------------------------------- | ---- |
+| 2026-04-18 | Issue #98 Server PR/push CI 추가: `ci.yml` 신규 구성, Node 20 + pnpm 고정, MySQL service + `.env.test` 생성, PR 중복 실행 방지를 위해 `push`를 `main`으로 제한, PR #99 머지 | ✅   |
 | 2026-04-18 | Issue #96 Server API `/api` prefix 제거: route prefix/OAuth callback/Swagger 설명/통합 테스트를 루트 경로로 전환, `/health` lightweight probe 유지 + 상세 상태는 `/health/status`로 분리, `api-spec.md` 갱신, PR #97 머지 | ✅   |
 | 2026-04-10 | Issue #87 API spec/test alignment baseline: auth/guestbook/settings 계약 기준 테스트 정렬, 실제 앱 CSRF e2e 검증 추가, health/stats/settings-service 불안정성 수정, 전체 스위트 `17` files / `258` tests green 복구, PR #90 머지 | ✅   |
 | 2026-04-10 | Issue #88 Dev uploads 상대 경로 계약 유지 및 정적 서빙 검증: upload dir/url prefix 공통화, static 플러그인에서 업로드 디렉토리 선생성, assets 통합 테스트에 `/uploads/...` 정적 접근 검증 추가, PR #89 머지 | ✅   |
@@ -63,6 +64,7 @@
 
 ## 🔗 상세 문서
 
+- [progress.2026-04-18.md](./progress/progress.2026-04-18.md) - Issue #98 Server PR/push CI 추가 + PR #99 머지
 - [progress.2026-04-18.md](./progress/progress.2026-04-18.md) - Issue #96 server API `/api` prefix 제거 + health probe 계약 유지 + PR #97 머지
 - [progress.2026-04-10.md](./progress/progress.2026-04-10.md) - Issue #87 API spec/test alignment baseline + PR #90 머지
 - [progress.2026-04-10.md](./progress/progress.2026-04-10.md) - Issue #88 uploads 상대 경로 계약/정적 서빙 검증 + PR #89 머지

--- a/docs/server/progress.index.md
+++ b/docs/server/progress.index.md
@@ -6,6 +6,7 @@
 
 | 날짜       | 주요 작업                              | 상태 |
 | ---------- | -------------------------------------- | ---- |
+| 2026-04-10 | Issue #88 Dev uploads 상대 경로 계약 유지 및 정적 서빙 검증: upload dir/url prefix 공통화, static 플러그인에서 업로드 디렉토리 선생성, assets 통합 테스트에 `/uploads/...` 정적 접근 검증 추가, PR #89 머지 | ✅   |
 | 2026-04-07 | Issue #84 발행 시 summary 자동 생성: published 저장 시 `contentMd` plain text 200자 summary 보장, draft→published `publishedAt` 보강, posts 테스트 추가, PR #85 머지 | ✅   |
 | 2026-04-06 | Issue #80 Admin auth route username contract 전환: login/me 응답에서 legacy `email` 필드 제거, request body를 `username` 단일 필드로 정리, migrated email-shaped username 호환 로그인 유지, PR #83 머지 | ✅   |
 | 2026-04-06 | Issue #79 Category/Asset mutation route CSRF 누락 수정: categories/assets 관리자 mutation route에 명시적 CSRF hook 추가, route introspection 테스트 보강, PR #82 머지 | ✅   |
@@ -60,6 +61,7 @@
 
 ## 🔗 상세 문서
 
+- [progress.2026-04-10.md](./progress/progress.2026-04-10.md) - Issue #88 uploads 상대 경로 계약/정적 서빙 검증 + PR #89 머지
 - [progress.2026-04-07.md](./progress/progress.2026-04-07.md) - Issue #84 발행 시 summary 자동 생성 + PR #85 머지
 - [progress.2026-04-06.md](./progress/progress.2026-04-06.md) - Issue #80 Admin auth route username contract 전환 + PR #83 머지
 - [progress.2026-04-06.md](./progress/progress.2026-04-06.md) - Issue #79 Category/Asset mutation route CSRF 누락 수정 + PR #82 머지

--- a/docs/server/progress.index.md
+++ b/docs/server/progress.index.md
@@ -6,6 +6,7 @@
 
 | 날짜       | 주요 작업                              | 상태 |
 | ---------- | -------------------------------------- | ---- |
+| 2026-04-06 | Issue #80 Admin auth route username contract 전환: login/me 응답에서 legacy `email` 필드 제거, request body를 `username` 단일 필드로 정리, migrated email-shaped username 호환 로그인 유지, PR #83 머지 | ✅   |
 | 2026-04-06 | Issue #79 Category/Asset mutation route CSRF 누락 수정: categories/assets 관리자 mutation route에 명시적 CSRF hook 추가, route introspection 테스트 보강, PR #82 머지 | ✅   |
 | 2026-04-02 | Issue #75 Admin 댓글 hidden 상태 전환 API 추가: 단건/벌크 hide, public/post commentCount 가시성 정렬, hide 경로 CSRF 적용, PR #76 머지 | ✅   |
 | 2026-03-29 | Issue #73 Admin pinned 글 상한(5개) 강제: pinned count 엔드포인트 추가, create/update/restore/delete 전이 동시성 잠금 정리, posts 테스트 보강, PR #74 머지 | ✅   |
@@ -58,6 +59,7 @@
 
 ## 🔗 상세 문서
 
+- [progress.2026-04-06.md](./progress/progress.2026-04-06.md) - Issue #80 Admin auth route username contract 전환 + PR #83 머지
 - [progress.2026-04-06.md](./progress/progress.2026-04-06.md) - Issue #79 Category/Asset mutation route CSRF 누락 수정 + PR #82 머지
 - [progress.2026-04-02.md](./progress/progress.2026-04-02.md) - Issue #75 Admin 댓글 hidden 상태 전환 API 추가 + PR #76 머지
 - [progress.2026-03-29.md](./progress/progress.2026-03-29.md) - Issue #73 Admin pinned 글 상한 5개 강제 + pinned count 엔드포인트 + PR #74 머지

--- a/docs/server/progress.index.md
+++ b/docs/server/progress.index.md
@@ -6,6 +6,7 @@
 
 | 날짜       | 주요 작업                              | 상태 |
 | ---------- | -------------------------------------- | ---- |
+| 2026-04-18 | Issue #96 Server API `/api` prefix 제거: route prefix/OAuth callback/Swagger 설명/통합 테스트를 루트 경로로 전환, `/health` lightweight probe 유지 + 상세 상태는 `/health/status`로 분리, `api-spec.md` 갱신, PR #97 머지 | ✅   |
 | 2026-04-10 | Issue #87 API spec/test alignment baseline: auth/guestbook/settings 계약 기준 테스트 정렬, 실제 앱 CSRF e2e 검증 추가, health/stats/settings-service 불안정성 수정, 전체 스위트 `17` files / `258` tests green 복구, PR #90 머지 | ✅   |
 | 2026-04-10 | Issue #88 Dev uploads 상대 경로 계약 유지 및 정적 서빙 검증: upload dir/url prefix 공통화, static 플러그인에서 업로드 디렉토리 선생성, assets 통합 테스트에 `/uploads/...` 정적 접근 검증 추가, PR #89 머지 | ✅   |
 | 2026-04-07 | Issue #84 발행 시 summary 자동 생성: published 저장 시 `contentMd` plain text 200자 summary 보장, draft→published `publishedAt` 보강, posts 테스트 추가, PR #85 머지 | ✅   |
@@ -62,6 +63,7 @@
 
 ## 🔗 상세 문서
 
+- [progress.2026-04-18.md](./progress/progress.2026-04-18.md) - Issue #96 server API `/api` prefix 제거 + health probe 계약 유지 + PR #97 머지
 - [progress.2026-04-10.md](./progress/progress.2026-04-10.md) - Issue #87 API spec/test alignment baseline + PR #90 머지
 - [progress.2026-04-10.md](./progress/progress.2026-04-10.md) - Issue #88 uploads 상대 경로 계약/정적 서빙 검증 + PR #89 머지
 - [progress.2026-04-07.md](./progress/progress.2026-04-07.md) - Issue #84 발행 시 summary 자동 생성 + PR #85 머지

--- a/docs/server/progress/progress.2026-04-06.md
+++ b/docs/server/progress/progress.2026-04-06.md
@@ -1,0 +1,17 @@
+# Progress: 2026-04-06
+
+## Completed
+
+- [x] Issue #79: Category/Asset mutation route CSRF 누락 수정 + PR #82 merge 완료
+  - `src/routes/categories/category.route.ts`의 `POST /api/categories`, `PATCH /api/categories/tree`, `PATCH /api/categories/:id`, `DELETE /api/categories/:id`에 `fastify.csrfProtection`을 명시적으로 연결해 `/api/admin/*` 바깥의 관리자 mutation route도 문서와 동일한 CSRF 보호를 받도록 정리
+  - `src/routes/assets/asset.route.ts`의 `DELETE /api/assets/:id`, `DELETE /api/assets/bulk`에 동일한 CSRF hook을 추가해 upload route와 보호 수준을 맞춤
+  - `test/routes/categories.test.ts`, `test/routes/assets.test.ts`에 `app.printRoutes({ includeHooks: true })` 기반 회귀 테스트를 추가해 test 환경의 no-op CSRF 플러그인 아래에서도 route-level hook 등록 누락을 검출하도록 보강
+  - Codex automated review 결과 `0 critical / 0 warning / 0 suggestion`으로 clean review 확인 후 PR #82 merge
+
+## Notes
+
+- 관련 PR: [PR #82](https://github.com/pyo-sh/pyosh-blog-be/pull/82)
+- 관련 이슈: #79
+- 검증 메모:
+  - `NODE_ENV=test ./node_modules/.bin/vitest run test/routes/categories.test.ts test/routes/assets.test.ts` 실행 후 `47`개 테스트 통과 확인
+  - `pnpm test` 전체 스위트는 변경 범위 밖의 기존 baseline 실패(`test/routes/guestbook.test.ts`, `test/routes/stats.test.ts`, `test/routes/health.test.ts`)를 동일하게 재현

--- a/docs/server/progress/progress.2026-04-06.md
+++ b/docs/server/progress/progress.2026-04-06.md
@@ -2,6 +2,11 @@
 
 ## Completed
 
+- [x] Issue #80: Admin auth route username contract 전환 + PR #83 merge 완료
+  - `src/routes/auth/auth.route.ts`에서 `POST /api/auth/admin/login` request body를 `{ username, password }`로 고정하고 legacy `email` alias 필드를 제거
+  - login response와 `GET /api/auth/me`의 admin 응답에서 legacy `email` 필드를 제거해 외부 계약을 `username` 중심으로 정리
+  - `username` 필드는 현재 username 형식과 `0008_admin_username.sql`로 마이그레이션된 email-shaped username을 모두 허용하도록 검증을 조정해 기존 관리자 계정 로그인 회귀를 방지
+  - `test/routes/auth.test.ts`에 legacy `email` 필드 거부, response shape, migrated email-shaped username 로그인 호환 시나리오를 추가하고 review 2건을 반영한 뒤 PR #83 merge
 - [x] Issue #79: Category/Asset mutation route CSRF 누락 수정 + PR #82 merge 완료
   - `src/routes/categories/category.route.ts`의 `POST /api/categories`, `PATCH /api/categories/tree`, `PATCH /api/categories/:id`, `DELETE /api/categories/:id`에 `fastify.csrfProtection`을 명시적으로 연결해 `/api/admin/*` 바깥의 관리자 mutation route도 문서와 동일한 CSRF 보호를 받도록 정리
   - `src/routes/assets/asset.route.ts`의 `DELETE /api/assets/:id`, `DELETE /api/assets/bulk`에 동일한 CSRF hook을 추가해 upload route와 보호 수준을 맞춤
@@ -10,6 +15,12 @@
 
 ## Notes
 
+- 관련 PR: [PR #83](https://github.com/pyo-sh/pyosh-blog-be/pull/83)
+- 관련 이슈: #80
+- 검증 메모:
+  - `pnpm exec tsc --noEmit` 통과
+  - `NODE_ENV=test pnpm exec vitest run test/routes/auth.test.ts` 실행 후 `11`개 테스트 통과 확인
+  - `pnpm test` 전체 스위트는 변경 범위 밖의 기존 baseline 실패(`test/routes/posts.test.ts`, `test/routes/comments.test.ts`)를 동일하게 재현
 - 관련 PR: [PR #82](https://github.com/pyo-sh/pyosh-blog-be/pull/82)
 - 관련 이슈: #79
 - 검증 메모:

--- a/docs/server/progress/progress.2026-04-07.md
+++ b/docs/server/progress/progress.2026-04-07.md
@@ -1,0 +1,17 @@
+# Progress: 2026-04-07
+
+## Completed
+
+- [x] Issue #84: 발행 시 summary 자동 생성으로 목록 계약 보장 + PR #85 merge 완료
+  - `src/routes/posts/post.service.ts`에 markdown → plain text 200자 summary 추출 로직을 추가하고, `POST /api/admin/posts`에서 `status=published` 저장 시 summary가 비어 있으면 서버가 자동 생성하도록 보강
+  - `PATCH /api/admin/posts/:id`에서도 published 저장 기준으로 summary를 재계산하도록 정리해 draft → published 전환과 published 글의 summary clear 후 저장 시 `contentMd` 기반 summary 보장을 회복
+  - 같은 publish transition에서 `publishedAt`이 비어 있는 draft 글은 자동으로 현재 시각을 채우도록 보완
+  - `test/routes/posts.test.ts`에 published create auto-summary, draft → published auto-summary, published summary regeneration 회귀 테스트를 추가하고 Codex automated review `0 critical / 0 warning / 0 suggestion` clean 결과 확인 후 PR #85 merge
+
+## Notes
+
+- 관련 PR: [PR #85](https://github.com/pyo-sh/pyosh-blog-be/pull/85)
+- 관련 이슈: #84
+- 검증 메모:
+  - `pnpm test --run test/routes/posts.test.ts` 실행 후 `78`개 테스트 통과 확인
+  - `pnpm test` 전체 스위트는 변경 범위 밖의 기존 baseline 실패(`test/routes/guestbook.test.ts`, `test/routes/stats.test.ts`, `test/routes/health.test.ts`)를 base branch와 동일하게 재현

--- a/docs/server/progress/progress.2026-04-10.md
+++ b/docs/server/progress/progress.2026-04-10.md
@@ -1,0 +1,21 @@
+# Server Progress - 2026-04-10
+
+## Issue #88 Dev uploads 상대 경로 계약 유지 및 정적 서빙 검증
+
+- PR: #89
+- 상태: 머지 완료
+
+### 변경 사항
+
+- 업로드 저장 루트와 `/uploads/` URL prefix 해석을 `src/shared/uploads.ts`로 공통화했다.
+- static 플러그인이 서버 시작 시 업로드 디렉토리를 먼저 생성하도록 보강해 dev 환경에서 정적 루트 부재 경고를 제거했다.
+- 파일 저장 `storageKey`를 POSIX 경로로 고정해 `/uploads/...` 상대 경로 계약을 일관되게 유지했다.
+- assets 통합 테스트에 업로드 후 실제 저장 파일 존재와 `/uploads/...` 정적 접근 성공 검증을 추가했다.
+
+### 검증
+
+- `pnpm compile:types`
+- `NODE_ENV=test ./node_modules/.bin/vitest run --pool forks --poolOptions.forks.singleFork test/routes/assets.test.ts`
+- `pnpm test` 실행
+  - 자산 테스트 24건은 통과
+  - 전체 스위트는 기존 실패(`guestbook`, `stats`, `health`, `settings.service`)로 실패

--- a/docs/server/progress/progress.2026-04-10.md
+++ b/docs/server/progress/progress.2026-04-10.md
@@ -1,5 +1,22 @@
 # Server Progress - 2026-04-10
 
+## Issue #87 API spec and test alignment baseline
+
+- PR: #90
+- 상태: 머지 완료
+
+### 변경 사항
+
+- `auth`, `guestbook`, `settings` 라우트 테스트를 현재 API 계약에 맞게 정렬하고, 상태 변경 요청에 필요한 CSRF 헤더/쿠키 처리 헬퍼를 정리했다.
+- `GET /api/auth/csrf-token` 경로와 실제 앱 라우팅을 대상으로 한 CSRF 통합 검증을 추가해 세션 기반 토큰 흐름을 end-to-end로 고정했다.
+- `health`, `stats`, `settings.service` 테스트의 앱/DB lifecycle과 SQL assertion 방식을 보강해 공유 pool 종료 및 최근 조회 dedupe로 인한 불안정성을 제거했다.
+- 누락돼 있던 guestbook 관리자 수정/벌크 경로와 guestbook 설정 조회·수정 커버리지를 추가해 red 상태였던 기준 테스트 스위트를 다시 green으로 복구했다.
+
+### 검증
+
+- `pnpm test`
+  - `17`개 파일, `258`개 테스트 통과
+
 ## Issue #88 Dev uploads 상대 경로 계약 유지 및 정적 서빙 검증
 
 - PR: #89

--- a/docs/server/progress/progress.2026-04-18.md
+++ b/docs/server/progress/progress.2026-04-18.md
@@ -1,0 +1,18 @@
+# Server Progress - 2026-04-18
+
+## Issue #96 Server API `/api` prefix 제거
+
+- PR: #97
+- 변경 범위:
+  - `src/app.ts`에서 공개/관리자/API 인증 route prefix를 `/api/...`에서 루트 경로로 정리
+  - OAuth callback URL을 `/auth/google/callback`, `/auth/github/callback`으로 전환
+  - `src/routes/**` Swagger 설명과 주석 문자열을 새 경로 계약으로 갱신
+  - `test/helpers/app.ts`, `test/routes/**` 통합 테스트 요청 경로를 새 계약으로 갱신
+  - `api-spec.md`를 구현과 동일한 루트 경로 기준으로 갱신
+- 리뷰 반영:
+  - 초기 변경에서 `/health`가 DB 의존 상태 체크로 바뀌는 회귀가 지적됨
+  - lightweight probe는 `GET /health`로 유지하고, 상세 상태 응답은 `GET /health/status`로 분리
+- 검증:
+  - `pnpm build`
+  - `pnpm test` → `17` files, `266` tests passed
+

--- a/docs/server/progress/progress.2026-04-18.md
+++ b/docs/server/progress/progress.2026-04-18.md
@@ -16,3 +16,16 @@
   - `pnpm build`
   - `pnpm test` → `17` files, `266` tests passed
 
+## Issue #98 Server PR/push CI 추가
+
+- PR: #99
+- 변경 범위:
+  - `server/.github/workflows/ci.yml` 신규 추가
+  - `pull_request`와 `main` 대상 `push`에서 Node 20 + pnpm 기반 CI 실행
+  - MySQL service와 `.env.test` 생성 step을 포함해 `pnpm compile:types`, `pnpm lint`, `pnpm test`, `pnpm build`를 PR 단계 검증으로 연결
+  - 리뷰 반영으로 open PR 중복 실행을 막기 위해 `push` 범위를 `main`으로 제한하고, pnpm 버전을 `10.33.0`으로 고정
+- 검증:
+  - `pnpm compile:types`
+  - `pnpm build`
+  - `pnpm lint` → 기존 베이스라인 lint 오류로 실패
+  - `pnpm test` → 로컬 DB 권한 부족으로 실패, CI에서는 workflow 내 MySQL service로 실행 예정


### PR DESCRIPTION
Squash-merge of 16 doc progress entries accumulated on the `docs` branch.

## Server
- CI workflow progress (#server-ci)
- API prefix removal refactor (related to client #310)
- Issue #79 – initial work
- Issue #84 – progress entry
- Issue #87 – progress entry
- Issue #88 – uploads static path fix

## Client
- Issue #286, #287 – baseline progress
- Issue #289 – progress entry
- Issue #295, #297, #298, #299 – feature/fix progress
- API prefix removal (#310)
- Login simplification refactor

## Cross-cutting
- Admin auth username contract decision