### PR TITLE
docs: archive client progress records for issues 314 and 316

### DIFF
--- a/docs/client/progress.index.md
+++ b/docs/client/progress.index.md
@@ -6,6 +6,7 @@
 
 | 날짜       | 주요 작업                            | 상태 |
 | ---------- | ------------------------------------ | ---- |
+| 2026-04-20 | #314 발행된 게시글 상세 페이지 404 및 slug 무결성 문제 - 댓글 preload 실패가 전체 `notFound()`로 전파되지 않도록 완화하고 PR #315 머지 | ✅   |
 | 2026-04-18 | #310 Client API 경로에서 `/api` prefix 제거 - client API helper, middleware auth 체크, Storybook/MSW 경로를 루트 기준으로 정렬하고 PR #311 머지 | ✅   |
 | 2026-04-10 | #299 Dev asset URL normalization and CSP split - `/uploads/...` 표시용 정규화, post/editor/asset copy canonical 경로 유지, dev CSP 허용 분리, 자동 리뷰 5라운드 반영 후 PR #304 머지 | ✅   |
 | 2026-04-10 | #298 Category empty state must keep management controls - 카테고리 empty state에서도 관리 toolbar를 유지하고, 자동 리뷰 suggestion을 반영해 빈 상태에서는 일괄 선택/배치 편집 액션을 숨긴 뒤 PR #303 머지 | ✅   |
@@ -90,6 +91,7 @@
 
 ## 🔗 상세 문서
 
+- [progress.2026-04-20.md](./progress/progress.2026-04-20.md) - #314 발행된 게시글 상세 페이지 404 및 slug 무결성 문제 1차 완화, PR #315 머지
 - [progress.2026-04-10.md](./progress/progress.2026-04-10.md) - #299 Dev asset URL normalization and CSP split PR #304 머지
 - [progress.2026-04-10.md](./progress/progress.2026-04-10.md) - #298 Category empty state must keep management controls PR #303 머지
 - [progress.2026-04-10.md](./progress/progress.2026-04-10.md) - #297 Admin routes must not render public header PR #302 머지

--- a/docs/client/progress.index.md
+++ b/docs/client/progress.index.md
@@ -6,6 +6,7 @@
 
 | 날짜       | 주요 작업                            | 상태 |
 | ---------- | ------------------------------------ | ---- |
+| 2026-04-22 | #316 게시글 상세 SSR slug double encoding으로 인한 404 수정 - 원래 slug 우선 조회 + 404 시 decode fallback으로 PR #317 머지 | ✅   |
 | 2026-04-20 | #314 발행된 게시글 상세 페이지 404 및 slug 무결성 문제 - 댓글 preload 실패가 전체 `notFound()`로 전파되지 않도록 완화하고 PR #315 머지 | ✅   |
 | 2026-04-18 | #310 Client API 경로에서 `/api` prefix 제거 - client API helper, middleware auth 체크, Storybook/MSW 경로를 루트 기준으로 정렬하고 PR #311 머지 | ✅   |
 | 2026-04-10 | #299 Dev asset URL normalization and CSP split - `/uploads/...` 표시용 정규화, post/editor/asset copy canonical 경로 유지, dev CSP 허용 분리, 자동 리뷰 5라운드 반영 후 PR #304 머지 | ✅   |
@@ -91,6 +92,7 @@
 
 ## 🔗 상세 문서
 
+- [progress.2026-04-22.md](./progress/progress.2026-04-22.md) - #316 게시글 상세 SSR slug double encoding 404 수정, PR #317 머지
 - [progress.2026-04-20.md](./progress/progress.2026-04-20.md) - #314 발행된 게시글 상세 페이지 404 및 slug 무결성 문제 1차 완화, PR #315 머지
 - [progress.2026-04-10.md](./progress/progress.2026-04-10.md) - #299 Dev asset URL normalization and CSP split PR #304 머지
 - [progress.2026-04-10.md](./progress/progress.2026-04-10.md) - #298 Category empty state must keep management controls PR #303 머지

--- a/docs/client/progress/progress.2026-04-20.md
+++ b/docs/client/progress/progress.2026-04-20.md
@@ -1,0 +1,27 @@
+# Client Progress - 2026-04-20
+
+## 완료된 작업
+
+### #314 발행된 게시글 상세 페이지 404 및 slug 무결성 문제 - 1차 완화 (PR #315 머지)
+
+운영 환경에서 발행된 게시글이 public 목록과 `api.pyosh.com/posts/{slug}`에서는 정상 조회되는데, Next.js public 상세 페이지에서는 `NEXT_NOT_FOUND`로 렌더되던 문제를 1차 완화했다. 원인 후보를 분리한 결과 상세 페이지는 게시글 본문 조회 외에도 댓글 preload 실패를 전체 `notFound()`로 전파할 수 있는 구조였고, 특히 `src/app/(public)/posts/[slug]/page.tsx`에서 댓글 요청 404를 재throw한 뒤 페이지 단위 catch가 이를 다시 `notFound()`로 바꾸고 있었다. 이번 변경에서는 게시글 조회만 404를 결정하도록 범위를 좁히고, 댓글 preload 실패는 댓글 섹션 에러 상태로만 처리하도록 조정했다. PR `#315`는 동기 `codex` 리뷰 clean 판정 후 병합됐다.
+
+**주요 변경 사항:**
+
+- `src/app/(public)/posts/[slug]/page.tsx`
+  - 페이지 전체를 감싸던 broad `try/catch`를 제거해 post lookup 외 404가 상세 페이지 전체를 `notFound()`로 바꾸지 않도록 정리
+  - `fetchComments(post.id, ...)` 실패 시 404 포함 모든 에러를 댓글 섹션 로딩 실패로만 처리하고, 사용자 메시지를 노출하도록 완화
+  - 결과적으로 게시글 상세 페이지의 404 결정권을 `getPostDetail()` 경로로 한정
+
+**검증:**
+
+- `pnpm install --frozen-lockfile`
+- `pnpm compile:types`
+- `pnpm lint` *(저장소 기존 warning 2건 유지)*
+- `pnpm build`
+
+**메모:**
+
+- `pnpm lint`는 저장소 기존 warning인 `src/features/post-editor/ui/image-gallery-modal.tsx`의 `<img>` 사용 1건과 `src/shared/ui/error-boundary.tsx`의 `_error` 미사용 1건만 남았다.
+- 이번 수정은 상세 페이지 404의 1차 완화다. 운영 API 응답에서 `category.slug === ""`, `tag.slug === ""`가 확인돼 slug 데이터 무결성 문제는 별도 후속 작업이 필요하다.
+- 게시글 URL 구조 자체는 여전히 slug-only에 의존하므로, 장기적으로는 stable id + display slug 구조 전환 검토가 남아 있다.

--- a/docs/client/progress/progress.2026-04-22.md
+++ b/docs/client/progress/progress.2026-04-22.md
@@ -1,0 +1,28 @@
+# Client Progress - 2026-04-22
+
+## 완료된 작업
+
+### #316 게시글 상세 SSR slug double encoding으로 인한 404 수정 (PR #317 머지)
+
+운영 환경에서 발행된 게시글 상세 페이지가 public 목록과 backend API에서는 정상 조회되는데도 `NEXT_NOT_FOUND`로 렌더되던 문제를 수정했다. 진단 로그로 확인한 결과, public 상세 SSR 경로에서 이미 percent-encoded 상태로 들어온 slug를 `fetchPostBySlug()`가 다시 `encodeURIComponent()` 하면서 `%EC...`가 `%25EC...`로 변형되고 있었고, 이로 인해 backend route miss 404가 발생했다. 수정은 `main` 브랜치 이슈 `#316` 기준으로 진행했고, `fetchPostBySlug()`가 먼저 원래 slug로 canonical path를 만들고, 404일 때만 decode fallback을 한 번 더 시도하도록 바꿨다. 이렇게 해서 실제로 인코딩된 경로 입력은 복구하면서도 문자 그대로의 `%xx` 시퀀스를 slug로 사용하는 경우의 회귀를 피했다. PR `#317`은 동기 `codex` 리뷰 2라운드 후 clean 판정으로 병합됐다.
+
+**주요 변경 사항:**
+
+- `src/entities/post/api.ts`
+  - `fetchPostBySlug()`에 slug path builder를 분리
+  - 1차 요청은 원래 slug를 `normalize("NFKC")` 후 canonical path로 조회
+  - 1차 요청이 404일 때만 `decodeURIComponent()` fallback을 시도하고, decode 결과가 원본과 다를 때에만 재조회
+  - `ApiResponseError(404)`가 아닌 에러는 그대로 전파
+
+**검증:**
+
+- `pnpm install --frozen-lockfile`
+- `pnpm compile:types`
+- `pnpm lint` *(저장소 기존 warning 2건 유지)*
+- `pnpm build`
+
+**메모:**
+
+- `pnpm lint`는 저장소 기존 warning인 `src/features/post-editor/ui/image-gallery-modal.tsx`의 `<img>` 사용 1건과 `src/shared/ui/error-boundary.tsx`의 `_error` 미사용 1건만 남았다.
+- 운영에서 사용한 임시 진단 로그는 별도 `release` 확인용 커밋으로만 다뤘고, 이번 `main` 머지에는 포함하지 않았다.
+- category/tag slug가 운영 DB에서 빈 문자열인 문제는 별도 후속 작업이 필요하다.


### PR DESCRIPTION
## Summary
- archive client progress records for issue #314 post detail 404 mitigation and issue #316 slug double-encoding fix
- record merged implementation context for PRs #315 and #317, including root causes, code paths, and verification commands
- update `docs/client/progress.index.md` with the 2026-04-20 and 2026-04-22 entries

## Included commits
- `2c5bc5c` docs: progress - issue 316 post slug encoding
- `76713eb` docs: progress - issue 314 post detail 404