### PR TITLE
docs: archive accumulated docs branch updates

### DIFF
--- a/docs/client/progress.index.md
+++ b/docs/client/progress.index.md
@@ -6,6 +6,7 @@
 
 | 날짜       | 주요 작업                            | 상태 |
 | ---------- | ------------------------------------ | ---- |
+| 2026-04-26 | #352 Sidebar 카테고리 UI 재디자인 보정 - sidebar leaf indicator slot/spacing과 overview typography를 wireframe 기준으로 다시 맞추고 nested overview toggle 회귀를 자동 리뷰 warning 1건 반영 후 PR #353 머지 | ✅   |
 | 2026-04-26 | #348 `/categories` 페이지 재디자인 - wireframe 기준 compact tree archive, stat strip, overview 전용 group/leaf 구조를 구현하고 자동 리뷰 warning 1건(숨겨진 link tab order)을 보정한 뒤 PR #351 머지 | ✅   |
 | 2026-04-26 | #349 사이드바 카테고리 트리 leaf 아이템 circle indicator 추가 - public sidebar에서 부모 카테고리는 chevron toggle을 유지하고 leaf 카테고리는 `solar:record-linear` circle marker + direct link row로 구분한 뒤 PR #350 머지 | ✅   |
 | 2026-04-26 | #346 Public 카테고리 내비게이션 UI 정리 - sidebar category label 밀도를 낮추고 leaf marker를 추가했으며 `/categories` overview를 compact list 스타일로 정리하고 category empty state shadow를 제거한 뒤 PR #347 머지 | ✅   |
@@ -110,6 +111,7 @@
 
 ## 🔗 상세 문서
 
+- [progress.2026-04-26.md](./progress/progress.2026-04-26.md) - #352 Sidebar 카테고리 UI 재디자인 보정, PR #353 머지
 - [progress.2026-04-26.md](./progress/progress.2026-04-26.md) - #348 `/categories` 페이지 재디자인, PR #351 머지
 - [progress.2026-04-26.md](./progress/progress.2026-04-26.md) - #349 사이드바 카테고리 트리 leaf 아이템 circle indicator 추가, PR #350 머지
 - [progress.2026-04-26.md](./progress/progress.2026-04-26.md) - #346 Public 카테고리 내비게이션 UI 정리, PR #347 머지

--- a/docs/client/progress.index.md
+++ b/docs/client/progress.index.md
@@ -6,6 +6,7 @@
 
 | 날짜       | 주요 작업                            | 상태 |
 | ---------- | ------------------------------------ | ---- |
+| 2026-04-25 | #332 카테고리 관리 모달 한글 IME 조합 끊김 수정 - shared modal 포커스 복원을 실제 close 전환으로 제한하고 PR #333 머지 | ✅   |
 | 2026-04-25 | #328 Category 이름 한글 IME 입력 회귀 수정 - ref 기반 IME-safe hook으로 카테고리/태그 입력을 정리하고 PR #331 머지 | ✅   |
 | 2026-04-25 | #329 Public post list item 링크 구조 정리 - overlay anchor를 제거하고 `Link`가 실제 item view를 감싸도록 바꾼 뒤 PR #330 머지 | ✅   |
 | 2026-04-25 | #326 Category/Tag 한글 slug 라우트 404 + Category 입력 한글 IME 분해 버그 수정 - shared slug 정규화 유틸 도입, category/tag route param 정규화, category name NFC 입력 보정 후 PR #327 머지 | ✅   |

--- a/docs/client/progress.index.md
+++ b/docs/client/progress.index.md
@@ -6,6 +6,7 @@
 
 | 날짜       | 주요 작업                            | 상태 |
 | ---------- | ------------------------------------ | ---- |
+| 2026-04-26 | #336 public 사이드바 모바일 헤더 겹침 및 데스크톱 border-right 정렬 수정 - 모바일 패널을 헤더 높이 아래로 오프셋하고 데스크톱 sidebar spacing을 `border-right + padding` 구조로 재정렬한 뒤 PR #338 머지 | ✅   |
 | 2026-04-25 | #334 Guestbook create type should allow missing guest email - `CreateGuestbookGuestBody.guestEmail`을 optional로 전환하고 PR #335 머지 | ✅   |
 | 2026-04-25 | #332 카테고리 관리 모달 한글 IME 조합 끊김 수정 - shared modal 포커스 복원을 실제 close 전환으로 제한하고 PR #333 머지 | ✅   |
 | 2026-04-25 | #328 Category 이름 한글 IME 입력 회귀 수정 - ref 기반 IME-safe hook으로 카테고리/태그 입력을 정리하고 PR #331 머지 | ✅   |
@@ -102,6 +103,7 @@
 
 ## 🔗 상세 문서
 
+- [progress.2026-04-26.md](./progress/progress.2026-04-26.md) - #336 public 사이드바 모바일 헤더 겹침 및 데스크톱 border-right 정렬 수정 PR #338 머지
 - [progress.2026-04-25.md](./progress/progress.2026-04-25.md) - #334 Guestbook create type should allow missing guest email PR #335 머지
 - [progress.2026-04-25.md](./progress/progress.2026-04-25.md) - #328 Category 이름 한글 IME 입력 회귀 수정 PR #331 머지
 - [progress.2026-04-25.md](./progress/progress.2026-04-25.md) - #329 Public post list item 링크 구조 정리 PR #330 머지

--- a/docs/client/progress.index.md
+++ b/docs/client/progress.index.md
@@ -6,6 +6,7 @@
 
 | 날짜       | 주요 작업                            | 상태 |
 | ---------- | ------------------------------------ | ---- |
+| 2026-04-25 | #334 Guestbook create type should allow missing guest email - `CreateGuestbookGuestBody.guestEmail`을 optional로 전환하고 PR #335 머지 | ✅   |
 | 2026-04-25 | #332 카테고리 관리 모달 한글 IME 조합 끊김 수정 - shared modal 포커스 복원을 실제 close 전환으로 제한하고 PR #333 머지 | ✅   |
 | 2026-04-25 | #328 Category 이름 한글 IME 입력 회귀 수정 - ref 기반 IME-safe hook으로 카테고리/태그 입력을 정리하고 PR #331 머지 | ✅   |
 | 2026-04-25 | #329 Public post list item 링크 구조 정리 - overlay anchor를 제거하고 `Link`가 실제 item view를 감싸도록 바꾼 뒤 PR #330 머지 | ✅   |
@@ -101,6 +102,7 @@
 
 ## 🔗 상세 문서
 
+- [progress.2026-04-25.md](./progress/progress.2026-04-25.md) - #334 Guestbook create type should allow missing guest email PR #335 머지
 - [progress.2026-04-25.md](./progress/progress.2026-04-25.md) - #328 Category 이름 한글 IME 입력 회귀 수정 PR #331 머지
 - [progress.2026-04-25.md](./progress/progress.2026-04-25.md) - #329 Public post list item 링크 구조 정리 PR #330 머지
 - [progress.2026-04-25.md](./progress/progress.2026-04-25.md) - #324 휴지통/관리자 화면에서 카테고리 NULL 글 표시 및 복원 UX 정리 PR #325 머지

--- a/docs/client/progress.index.md
+++ b/docs/client/progress.index.md
@@ -6,6 +6,7 @@
 
 | 날짜       | 주요 작업                            | 상태 |
 | ---------- | ------------------------------------ | ---- |
+| 2026-04-25 | #329 Public post list item 링크 구조 정리 - overlay anchor를 제거하고 `Link`가 실제 item view를 감싸도록 바꾼 뒤 PR #330 머지 | ✅   |
 | 2026-04-25 | #326 Category/Tag 한글 slug 라우트 404 + Category 입력 한글 IME 분해 버그 수정 - shared slug 정규화 유틸 도입, category/tag route param 정규화, category name NFC 입력 보정 후 PR #327 머지 | ✅   |
 | 2026-04-25 | #324 휴지통/관리자 화면에서 카테고리 NULL 글 표시 및 복원 UX 정리 - 관리자 post 타입 nullable 전환, orphan 글 `(카테고리 없음)` 표시, 복원 전 카테고리 재지정 모달 추가, public 상세 nullable guard 정리 후 PR #325 머지 | ✅   |
 | 2026-04-24 | #313 Preview 배포 인덱싱 차단 및 sitemap/robots SEO 점검 - non-production `X-Robots-Tag` 헤더를 middleware에 추가하고, 운영 도메인/비-Vercel production 예외를 보정한 뒤 PR #323 머지 | ✅   |
@@ -98,6 +99,7 @@
 
 ## 🔗 상세 문서
 
+- [progress.2026-04-25.md](./progress/progress.2026-04-25.md) - #329 Public post list item 링크 구조 정리 PR #330 머지
 - [progress.2026-04-25.md](./progress/progress.2026-04-25.md) - #324 휴지통/관리자 화면에서 카테고리 NULL 글 표시 및 복원 UX 정리 PR #325 머지
 - [progress.2026-04-24.md](./progress/progress.2026-04-24.md) - #313 Preview 배포 인덱싱 차단 및 sitemap/robots SEO 점검 PR #323 머지
 - [progress.2026-04-24.md](./progress/progress.2026-04-24.md) - #312 원격 게시글 이미지 호스트 확장 PR #322 머지

--- a/docs/client/progress.index.md
+++ b/docs/client/progress.index.md
@@ -6,6 +6,7 @@
 
 | 날짜       | 주요 작업                            | 상태 |
 | ---------- | ------------------------------------ | ---- |
+| 2026-04-26 | #352 public category tree spacing/icon 후속 보정 - sidebar와 `/categories` toggle slot을 다시 키우고 row spacing과 overview child indent를 wireframe 기준으로 복구한 뒤 PR #355 머지 | ✅   |
 | 2026-04-26 | #352 public category tree 정렬/고정 count column 후속 보정 - sidebar와 `/categories` row를 중앙 정렬 기준으로 다시 맞추고 overview count를 고정 right column으로 정렬한 뒤 자동 리뷰 suggestion 1건(hover color inheritance)을 반영해 PR #354 머지 | ✅   |
 | 2026-04-26 | #352 Sidebar 카테고리 UI 재디자인 보정 - sidebar leaf indicator slot/spacing과 overview typography를 wireframe 기준으로 다시 맞추고 nested overview toggle 회귀를 자동 리뷰 warning 1건 반영 후 PR #353 머지 | ✅   |
 | 2026-04-26 | #348 `/categories` 페이지 재디자인 - wireframe 기준 compact tree archive, stat strip, overview 전용 group/leaf 구조를 구현하고 자동 리뷰 warning 1건(숨겨진 link tab order)을 보정한 뒤 PR #351 머지 | ✅   |
@@ -112,6 +113,7 @@
 
 ## 🔗 상세 문서
 
+- [progress.2026-04-26.md](./progress/progress.2026-04-26.md) - #352 public category tree spacing/icon 후속 보정, PR #355 머지
 - [progress.2026-04-26.md](./progress/progress.2026-04-26.md) - #352 public category tree 정렬/고정 count column 후속 보정, PR #354 머지
 - [progress.2026-04-26.md](./progress/progress.2026-04-26.md) - #352 Sidebar 카테고리 UI 재디자인 보정, PR #353 머지
 - [progress.2026-04-26.md](./progress/progress.2026-04-26.md) - #348 `/categories` 페이지 재디자인, PR #351 머지

--- a/docs/client/progress.index.md
+++ b/docs/client/progress.index.md
@@ -6,6 +6,7 @@
 
 | 날짜       | 주요 작업                            | 상태 |
 | ---------- | ------------------------------------ | ---- |
+| 2026-04-25 | #326 Category/Tag 한글 slug 라우트 404 + Category 입력 한글 IME 분해 버그 수정 - shared slug 정규화 유틸 도입, category/tag route param 정규화, category name NFC 입력 보정 후 PR #327 머지 | ✅   |
 | 2026-04-25 | #324 휴지통/관리자 화면에서 카테고리 NULL 글 표시 및 복원 UX 정리 - 관리자 post 타입 nullable 전환, orphan 글 `(카테고리 없음)` 표시, 복원 전 카테고리 재지정 모달 추가, public 상세 nullable guard 정리 후 PR #325 머지 | ✅   |
 | 2026-04-24 | #313 Preview 배포 인덱싱 차단 및 sitemap/robots SEO 점검 - non-production `X-Robots-Tag` 헤더를 middleware에 추가하고, 운영 도메인/비-Vercel production 예외를 보정한 뒤 PR #323 머지 | ✅   |
 | 2026-04-24 | #312 원격 게시글 이미지 호스트 확장 - `api.pyosh.com`과 GitHub/Notion/Naver 계열 호스트를 `next/image` 허용 목록에 추가하고 wildcard 매칭을 Next semantics에 맞춘 뒤 PR #322 머지 | ✅   |

--- a/docs/client/progress.index.md
+++ b/docs/client/progress.index.md
@@ -6,6 +6,7 @@
 
 | 날짜       | 주요 작업                            | 상태 |
 | ---------- | ------------------------------------ | ---- |
+| 2026-04-25 | #324 휴지통/관리자 화면에서 카테고리 NULL 글 표시 및 복원 UX 정리 - 관리자 post 타입 nullable 전환, orphan 글 `(카테고리 없음)` 표시, 복원 전 카테고리 재지정 모달 추가, public 상세 nullable guard 정리 후 PR #325 머지 | ✅   |
 | 2026-04-24 | #313 Preview 배포 인덱싱 차단 및 sitemap/robots SEO 점검 - non-production `X-Robots-Tag` 헤더를 middleware에 추가하고, 운영 도메인/비-Vercel production 예외를 보정한 뒤 PR #323 머지 | ✅   |
 | 2026-04-24 | #312 원격 게시글 이미지 호스트 확장 - `api.pyosh.com`과 GitHub/Notion/Naver 계열 호스트를 `next/image` 허용 목록에 추가하고 wildcard 매칭을 Next semantics에 맞춘 뒤 PR #322 머지 | ✅   |
 | 2026-04-24 | #319 헤더에 방명록 네비게이션 링크 추가 - 공개 헤더 액션 영역에 `/guestbook` 링크를 추가하고 PR #321 머지 | ✅   |
@@ -96,6 +97,7 @@
 
 ## 🔗 상세 문서
 
+- [progress.2026-04-25.md](./progress/progress.2026-04-25.md) - #324 휴지통/관리자 화면에서 카테고리 NULL 글 표시 및 복원 UX 정리 PR #325 머지
 - [progress.2026-04-24.md](./progress/progress.2026-04-24.md) - #313 Preview 배포 인덱싱 차단 및 sitemap/robots SEO 점검 PR #323 머지
 - [progress.2026-04-24.md](./progress/progress.2026-04-24.md) - #312 원격 게시글 이미지 호스트 확장 PR #322 머지
 - [progress.2026-04-24.md](./progress/progress.2026-04-24.md) - #319 헤더에 방명록 네비게이션 링크 추가 PR #321 머지

--- a/docs/client/progress.index.md
+++ b/docs/client/progress.index.md
@@ -6,6 +6,7 @@
 
 | 날짜       | 주요 작업                            | 상태 |
 | ---------- | ------------------------------------ | ---- |
+| 2026-04-25 | #328 Category 이름 한글 IME 입력 회귀 수정 - ref 기반 IME-safe hook으로 카테고리/태그 입력을 정리하고 PR #331 머지 | ✅   |
 | 2026-04-25 | #329 Public post list item 링크 구조 정리 - overlay anchor를 제거하고 `Link`가 실제 item view를 감싸도록 바꾼 뒤 PR #330 머지 | ✅   |
 | 2026-04-25 | #326 Category/Tag 한글 slug 라우트 404 + Category 입력 한글 IME 분해 버그 수정 - shared slug 정규화 유틸 도입, category/tag route param 정규화, category name NFC 입력 보정 후 PR #327 머지 | ✅   |
 | 2026-04-25 | #324 휴지통/관리자 화면에서 카테고리 NULL 글 표시 및 복원 UX 정리 - 관리자 post 타입 nullable 전환, orphan 글 `(카테고리 없음)` 표시, 복원 전 카테고리 재지정 모달 추가, public 상세 nullable guard 정리 후 PR #325 머지 | ✅   |
@@ -99,6 +100,7 @@
 
 ## 🔗 상세 문서
 
+- [progress.2026-04-25.md](./progress/progress.2026-04-25.md) - #328 Category 이름 한글 IME 입력 회귀 수정 PR #331 머지
 - [progress.2026-04-25.md](./progress/progress.2026-04-25.md) - #329 Public post list item 링크 구조 정리 PR #330 머지
 - [progress.2026-04-25.md](./progress/progress.2026-04-25.md) - #324 휴지통/관리자 화면에서 카테고리 NULL 글 표시 및 복원 UX 정리 PR #325 머지
 - [progress.2026-04-24.md](./progress/progress.2026-04-24.md) - #313 Preview 배포 인덱싱 차단 및 sitemap/robots SEO 점검 PR #323 머지

--- a/docs/client/progress.index.md
+++ b/docs/client/progress.index.md
@@ -6,6 +6,7 @@
 
 | 날짜       | 주요 작업                            | 상태 |
 | ---------- | ------------------------------------ | ---- |
+| 2026-04-26 | #348 `/categories` 페이지 재디자인 - wireframe 기준 compact tree archive, stat strip, overview 전용 group/leaf 구조를 구현하고 자동 리뷰 warning 1건(숨겨진 link tab order)을 보정한 뒤 PR #351 머지 | ✅   |
 | 2026-04-26 | #349 사이드바 카테고리 트리 leaf 아이템 circle indicator 추가 - public sidebar에서 부모 카테고리는 chevron toggle을 유지하고 leaf 카테고리는 `solar:record-linear` circle marker + direct link row로 구분한 뒤 PR #350 머지 | ✅   |
 | 2026-04-26 | #346 Public 카테고리 내비게이션 UI 정리 - sidebar category label 밀도를 낮추고 leaf marker를 추가했으며 `/categories` overview를 compact list 스타일로 정리하고 category empty state shadow를 제거한 뒤 PR #347 머지 | ✅   |
 | 2026-04-26 | #344 Categories/Tags 헤더 디자인 통일 및 categories 목록/퍼블릭 사이드바 UI 개선 - `/categories`·`/categories/[slug]`·`/tags` 헤더를 shared archive title system으로 통일하고 categories overview item을 card형으로 재구성하며 desktop public sidebar 폭을 `240px`로 보정한 뒤 PR #345 머지 | ✅   |
@@ -109,6 +110,7 @@
 
 ## 🔗 상세 문서
 
+- [progress.2026-04-26.md](./progress/progress.2026-04-26.md) - #348 `/categories` 페이지 재디자인, PR #351 머지
 - [progress.2026-04-26.md](./progress/progress.2026-04-26.md) - #349 사이드바 카테고리 트리 leaf 아이템 circle indicator 추가, PR #350 머지
 - [progress.2026-04-26.md](./progress/progress.2026-04-26.md) - #346 Public 카테고리 내비게이션 UI 정리, PR #347 머지
 - [progress.2026-04-26.md](./progress/progress.2026-04-26.md) - #344 Categories/Tags 헤더 디자인 통일 및 categories 목록/퍼블릭 사이드바 UI 개선, PR #345 머지

--- a/docs/client/progress.index.md
+++ b/docs/client/progress.index.md
@@ -6,6 +6,7 @@
 
 | 날짜       | 주요 작업                            | 상태 |
 | ---------- | ------------------------------------ | ---- |
+| 2026-04-26 | #346 Public 카테고리 내비게이션 UI 정리 - sidebar category label 밀도를 낮추고 leaf marker를 추가했으며 `/categories` overview를 compact list 스타일로 정리하고 category empty state shadow를 제거한 뒤 PR #347 머지 | ✅   |
 | 2026-04-26 | #344 Categories/Tags 헤더 디자인 통일 및 categories 목록/퍼블릭 사이드바 UI 개선 - `/categories`·`/categories/[slug]`·`/tags` 헤더를 shared archive title system으로 통일하고 categories overview item을 card형으로 재구성하며 desktop public sidebar 폭을 `240px`로 보정한 뒤 PR #345 머지 | ✅   |
 | 2026-04-26 | #342 카테고리 전체보기 500 오류 수정 - server route가 client export를 호출하지 않도록 category count helper를 분리하고 public sidebar divider 위치를 보정한 뒤 PR #343 머지 | ✅   |
 | 2026-04-26 | #340 Public sidebar 카테고리 섹션 정리 및 active path auto-expand - 카테고리 섹션 제목/전체보기 액션을 정리하고 category/post 현재 경로만 자동 expand되도록 tree seed를 분리한 뒤 자동 리뷰 warning 1건 보정 후 PR #341 머지 | ✅   |
@@ -107,6 +108,7 @@
 
 ## 🔗 상세 문서
 
+- [progress.2026-04-26.md](./progress/progress.2026-04-26.md) - #346 Public 카테고리 내비게이션 UI 정리, PR #347 머지
 - [progress.2026-04-26.md](./progress/progress.2026-04-26.md) - #344 Categories/Tags 헤더 디자인 통일 및 categories 목록/퍼블릭 사이드바 UI 개선, PR #345 머지
 - [progress.2026-04-26.md](./progress/progress.2026-04-26.md) - #342 카테고리 전체보기 500 오류 수정 및 sidebar divider 위치 조정, PR #343 머지
 - [progress.2026-04-26.md](./progress/progress.2026-04-26.md) - #340 Public sidebar 카테고리 섹션 정리 및 active path auto-expand, PR #341 머지

--- a/docs/client/progress.index.md
+++ b/docs/client/progress.index.md
@@ -6,6 +6,7 @@
 
 | 날짜       | 주요 작업                            | 상태 |
 | ---------- | ------------------------------------ | ---- |
+| 2026-04-29 | #359 관리자 카테고리 배치 편집 3-depth 하위 노드 이동 시 중간 노드가 사라지는 문제 - `removeCategory()` 재귀 복귀 대입을 제거하고 자동 리뷰 clean 후 PR #361 머지 | ✅   |
 | 2026-04-27 | #352 public category tree view 분리 - sidebar와 `/categories` renderer를 분리하고 공유 로직만 lib로 추출했으며 `/categories` Storybook을 추가한 뒤 PR #356 생성 | ✅   |
 | 2026-04-26 | #352 public category tree spacing/icon 후속 보정 - sidebar와 `/categories` toggle slot을 다시 키우고 row spacing과 overview child indent를 wireframe 기준으로 복구한 뒤 PR #355 머지 | ✅   |
 | 2026-04-26 | #352 public category tree 정렬/고정 count column 후속 보정 - sidebar와 `/categories` row를 중앙 정렬 기준으로 다시 맞추고 overview count를 고정 right column으로 정렬한 뒤 자동 리뷰 suggestion 1건(hover color inheritance)을 반영해 PR #354 머지 | ✅   |
@@ -114,6 +115,7 @@
 
 ## 🔗 상세 문서
 
+- [progress.2026-04-29.md](./progress/progress.2026-04-29.md) - #359 관리자 카테고리 배치 편집 3-depth 하위 노드 이동 시 중간 노드 누락 수정, PR #361 머지
 - [progress.2026-04-27.md](./progress/progress.2026-04-27.md) - #352 public category tree view 분리 및 `/categories` Storybook 추가, PR #356 생성
 - [progress.2026-04-26.md](./progress/progress.2026-04-26.md) - #352 public category tree spacing/icon 후속 보정, PR #355 머지
 - [progress.2026-04-26.md](./progress/progress.2026-04-26.md) - #352 public category tree 정렬/고정 count column 후속 보정, PR #354 머지

--- a/docs/client/progress.index.md
+++ b/docs/client/progress.index.md
@@ -6,6 +6,7 @@
 
 | 날짜       | 주요 작업                            | 상태 |
 | ---------- | ------------------------------------ | ---- |
+| 2026-04-29 | #360 관리자 카테고리 일괄 삭제 액션 - `DELETE /categories/bulk` 클라이언트 API와 선택 모드 삭제 버튼/확인 모달을 추가하고 자동 리뷰 clean 후 PR #362 머지 | ✅   |
 | 2026-04-29 | #359 관리자 카테고리 배치 편집 3-depth 하위 노드 이동 시 중간 노드가 사라지는 문제 - `removeCategory()` 재귀 복귀 대입을 제거하고 자동 리뷰 clean 후 PR #361 머지 | ✅   |
 | 2026-04-27 | #352 public category tree view 분리 - sidebar와 `/categories` renderer를 분리하고 공유 로직만 lib로 추출했으며 `/categories` Storybook을 추가한 뒤 PR #356 생성 | ✅   |
 | 2026-04-26 | #352 public category tree spacing/icon 후속 보정 - sidebar와 `/categories` toggle slot을 다시 키우고 row spacing과 overview child indent를 wireframe 기준으로 복구한 뒤 PR #355 머지 | ✅   |
@@ -115,6 +116,7 @@
 
 ## 🔗 상세 문서
 
+- [progress.2026-04-29.md](./progress/progress.2026-04-29.md) - #360 관리자 카테고리 일괄 삭제 액션, PR #362 머지
 - [progress.2026-04-29.md](./progress/progress.2026-04-29.md) - #359 관리자 카테고리 배치 편집 3-depth 하위 노드 이동 시 중간 노드 누락 수정, PR #361 머지
 - [progress.2026-04-27.md](./progress/progress.2026-04-27.md) - #352 public category tree view 분리 및 `/categories` Storybook 추가, PR #356 생성
 - [progress.2026-04-26.md](./progress/progress.2026-04-26.md) - #352 public category tree spacing/icon 후속 보정, PR #355 머지

--- a/docs/client/progress.index.md
+++ b/docs/client/progress.index.md
@@ -6,6 +6,7 @@
 
 | 날짜       | 주요 작업                            | 상태 |
 | ---------- | ------------------------------------ | ---- |
+| 2026-04-26 | #337 public 비밀글 안내 문구 한글화 - legacy 영어/한국어 secret mask를 모두 인식하고 public 표시 문구를 `비공개입니다.` 로 통일한 뒤 PR #339 머지 | ✅   |
 | 2026-04-26 | #336 public 사이드바 모바일 헤더 겹침 및 데스크톱 border-right 정렬 수정 - 모바일 패널을 헤더 높이 아래로 오프셋하고 데스크톱 sidebar spacing을 `border-right + padding` 구조로 재정렬한 뒤 PR #338 머지 | ✅   |
 | 2026-04-25 | #334 Guestbook create type should allow missing guest email - `CreateGuestbookGuestBody.guestEmail`을 optional로 전환하고 PR #335 머지 | ✅   |
 | 2026-04-25 | #332 카테고리 관리 모달 한글 IME 조합 끊김 수정 - shared modal 포커스 복원을 실제 close 전환으로 제한하고 PR #333 머지 | ✅   |
@@ -112,6 +113,7 @@
 - [progress.2026-04-24.md](./progress/progress.2026-04-24.md) - #312 원격 게시글 이미지 호스트 확장 PR #322 머지
 - [progress.2026-04-24.md](./progress/progress.2026-04-24.md) - #319 헤더에 방명록 네비게이션 링크 추가 PR #321 머지
 - [progress.2026-04-24.md](./progress/progress.2026-04-24.md) - #318 `/categories` 아카이브 페이지 추가 및 사이드바 전체보기 링크 404 prefetch 해소 PR #320 머지
+- [progress.2026-04-26.md](./progress/progress.2026-04-26.md) - #337 public 비밀글 안내 문구 한글화, PR #339 머지
 - [progress.2026-04-22.md](./progress/progress.2026-04-22.md) - #316 게시글 상세 SSR slug double encoding 404 수정, PR #317 머지
 - [progress.2026-04-20.md](./progress/progress.2026-04-20.md) - #314 발행된 게시글 상세 페이지 404 및 slug 무결성 문제 1차 완화, PR #315 머지
 - [progress.2026-04-10.md](./progress/progress.2026-04-10.md) - #299 Dev asset URL normalization and CSP split PR #304 머지

--- a/docs/client/progress.index.md
+++ b/docs/client/progress.index.md
@@ -6,6 +6,7 @@
 
 | 날짜       | 주요 작업                            | 상태 |
 | ---------- | ------------------------------------ | ---- |
+| 2026-04-24 | #319 헤더에 방명록 네비게이션 링크 추가 - 공개 헤더 액션 영역에 `/guestbook` 링크를 추가하고 PR #321 머지 | ✅   |
 | 2026-04-24 | #318 `/categories` 아카이브 페이지 추가 및 사이드바 전체보기 링크 404 prefetch 해소 - PR #320 머지 | ✅   |
 | 2026-04-22 | #316 게시글 상세 SSR slug double encoding으로 인한 404 수정 - 원래 slug 우선 조회 + 404 시 decode fallback으로 PR #317 머지 | ✅   |
 | 2026-04-20 | #314 발행된 게시글 상세 페이지 404 및 slug 무결성 문제 - 댓글 preload 실패가 전체 `notFound()`로 전파되지 않도록 완화하고 PR #315 머지 | ✅   |
@@ -93,6 +94,7 @@
 
 ## 🔗 상세 문서
 
+- [progress.2026-04-24.md](./progress/progress.2026-04-24.md) - #319 헤더에 방명록 네비게이션 링크 추가 PR #321 머지
 - [progress.2026-04-24.md](./progress/progress.2026-04-24.md) - #318 `/categories` 아카이브 페이지 추가 및 사이드바 전체보기 링크 404 prefetch 해소 PR #320 머지
 - [progress.2026-04-22.md](./progress/progress.2026-04-22.md) - #316 게시글 상세 SSR slug double encoding 404 수정, PR #317 머지
 - [progress.2026-04-20.md](./progress/progress.2026-04-20.md) - #314 발행된 게시글 상세 페이지 404 및 slug 무결성 문제 1차 완화, PR #315 머지

--- a/docs/client/progress.index.md
+++ b/docs/client/progress.index.md
@@ -6,6 +6,7 @@
 
 | 날짜       | 주요 작업                            | 상태 |
 | ---------- | ------------------------------------ | ---- |
+| 2026-04-27 | #352 public category tree view 분리 - sidebar와 `/categories` renderer를 분리하고 공유 로직만 lib로 추출했으며 `/categories` Storybook을 추가한 뒤 PR #356 생성 | ✅   |
 | 2026-04-26 | #352 public category tree spacing/icon 후속 보정 - sidebar와 `/categories` toggle slot을 다시 키우고 row spacing과 overview child indent를 wireframe 기준으로 복구한 뒤 PR #355 머지 | ✅   |
 | 2026-04-26 | #352 public category tree 정렬/고정 count column 후속 보정 - sidebar와 `/categories` row를 중앙 정렬 기준으로 다시 맞추고 overview count를 고정 right column으로 정렬한 뒤 자동 리뷰 suggestion 1건(hover color inheritance)을 반영해 PR #354 머지 | ✅   |
 | 2026-04-26 | #352 Sidebar 카테고리 UI 재디자인 보정 - sidebar leaf indicator slot/spacing과 overview typography를 wireframe 기준으로 다시 맞추고 nested overview toggle 회귀를 자동 리뷰 warning 1건 반영 후 PR #353 머지 | ✅   |
@@ -113,6 +114,7 @@
 
 ## 🔗 상세 문서
 
+- [progress.2026-04-27.md](./progress/progress.2026-04-27.md) - #352 public category tree view 분리 및 `/categories` Storybook 추가, PR #356 생성
 - [progress.2026-04-26.md](./progress/progress.2026-04-26.md) - #352 public category tree spacing/icon 후속 보정, PR #355 머지
 - [progress.2026-04-26.md](./progress/progress.2026-04-26.md) - #352 public category tree 정렬/고정 count column 후속 보정, PR #354 머지
 - [progress.2026-04-26.md](./progress/progress.2026-04-26.md) - #352 Sidebar 카테고리 UI 재디자인 보정, PR #353 머지

--- a/docs/client/progress.index.md
+++ b/docs/client/progress.index.md
@@ -6,6 +6,7 @@
 
 | 날짜       | 주요 작업                            | 상태 |
 | ---------- | ------------------------------------ | ---- |
+| 2026-04-24 | #312 원격 게시글 이미지 호스트 확장 - `api.pyosh.com`과 GitHub/Notion/Naver 계열 호스트를 `next/image` 허용 목록에 추가하고 wildcard 매칭을 Next semantics에 맞춘 뒤 PR #322 머지 | ✅   |
 | 2026-04-24 | #319 헤더에 방명록 네비게이션 링크 추가 - 공개 헤더 액션 영역에 `/guestbook` 링크를 추가하고 PR #321 머지 | ✅   |
 | 2026-04-24 | #318 `/categories` 아카이브 페이지 추가 및 사이드바 전체보기 링크 404 prefetch 해소 - PR #320 머지 | ✅   |
 | 2026-04-22 | #316 게시글 상세 SSR slug double encoding으로 인한 404 수정 - 원래 slug 우선 조회 + 404 시 decode fallback으로 PR #317 머지 | ✅   |
@@ -94,6 +95,7 @@
 
 ## 🔗 상세 문서
 
+- [progress.2026-04-24.md](./progress/progress.2026-04-24.md) - #312 원격 게시글 이미지 호스트 확장 PR #322 머지
 - [progress.2026-04-24.md](./progress/progress.2026-04-24.md) - #319 헤더에 방명록 네비게이션 링크 추가 PR #321 머지
 - [progress.2026-04-24.md](./progress/progress.2026-04-24.md) - #318 `/categories` 아카이브 페이지 추가 및 사이드바 전체보기 링크 404 prefetch 해소 PR #320 머지
 - [progress.2026-04-22.md](./progress/progress.2026-04-22.md) - #316 게시글 상세 SSR slug double encoding 404 수정, PR #317 머지

--- a/docs/client/progress.index.md
+++ b/docs/client/progress.index.md
@@ -6,6 +6,7 @@
 
 | 날짜       | 주요 작업                            | 상태 |
 | ---------- | ------------------------------------ | ---- |
+| 2026-04-24 | #318 `/categories` 아카이브 페이지 추가 및 사이드바 전체보기 링크 404 prefetch 해소 - PR #320 머지 | ✅   |
 | 2026-04-22 | #316 게시글 상세 SSR slug double encoding으로 인한 404 수정 - 원래 slug 우선 조회 + 404 시 decode fallback으로 PR #317 머지 | ✅   |
 | 2026-04-20 | #314 발행된 게시글 상세 페이지 404 및 slug 무결성 문제 - 댓글 preload 실패가 전체 `notFound()`로 전파되지 않도록 완화하고 PR #315 머지 | ✅   |
 | 2026-04-18 | #310 Client API 경로에서 `/api` prefix 제거 - client API helper, middleware auth 체크, Storybook/MSW 경로를 루트 기준으로 정렬하고 PR #311 머지 | ✅   |
@@ -92,6 +93,7 @@
 
 ## 🔗 상세 문서
 
+- [progress.2026-04-24.md](./progress/progress.2026-04-24.md) - #318 `/categories` 아카이브 페이지 추가 및 사이드바 전체보기 링크 404 prefetch 해소 PR #320 머지
 - [progress.2026-04-22.md](./progress/progress.2026-04-22.md) - #316 게시글 상세 SSR slug double encoding 404 수정, PR #317 머지
 - [progress.2026-04-20.md](./progress/progress.2026-04-20.md) - #314 발행된 게시글 상세 페이지 404 및 slug 무결성 문제 1차 완화, PR #315 머지
 - [progress.2026-04-10.md](./progress/progress.2026-04-10.md) - #299 Dev asset URL normalization and CSP split PR #304 머지

--- a/docs/client/progress.index.md
+++ b/docs/client/progress.index.md
@@ -6,6 +6,7 @@
 
 | 날짜       | 주요 작업                            | 상태 |
 | ---------- | ------------------------------------ | ---- |
+| 2026-04-26 | #352 public category tree 정렬/고정 count column 후속 보정 - sidebar와 `/categories` row를 중앙 정렬 기준으로 다시 맞추고 overview count를 고정 right column으로 정렬한 뒤 자동 리뷰 suggestion 1건(hover color inheritance)을 반영해 PR #354 머지 | ✅   |
 | 2026-04-26 | #352 Sidebar 카테고리 UI 재디자인 보정 - sidebar leaf indicator slot/spacing과 overview typography를 wireframe 기준으로 다시 맞추고 nested overview toggle 회귀를 자동 리뷰 warning 1건 반영 후 PR #353 머지 | ✅   |
 | 2026-04-26 | #348 `/categories` 페이지 재디자인 - wireframe 기준 compact tree archive, stat strip, overview 전용 group/leaf 구조를 구현하고 자동 리뷰 warning 1건(숨겨진 link tab order)을 보정한 뒤 PR #351 머지 | ✅   |
 | 2026-04-26 | #349 사이드바 카테고리 트리 leaf 아이템 circle indicator 추가 - public sidebar에서 부모 카테고리는 chevron toggle을 유지하고 leaf 카테고리는 `solar:record-linear` circle marker + direct link row로 구분한 뒤 PR #350 머지 | ✅   |
@@ -111,6 +112,7 @@
 
 ## 🔗 상세 문서
 
+- [progress.2026-04-26.md](./progress/progress.2026-04-26.md) - #352 public category tree 정렬/고정 count column 후속 보정, PR #354 머지
 - [progress.2026-04-26.md](./progress/progress.2026-04-26.md) - #352 Sidebar 카테고리 UI 재디자인 보정, PR #353 머지
 - [progress.2026-04-26.md](./progress/progress.2026-04-26.md) - #348 `/categories` 페이지 재디자인, PR #351 머지
 - [progress.2026-04-26.md](./progress/progress.2026-04-26.md) - #349 사이드바 카테고리 트리 leaf 아이템 circle indicator 추가, PR #350 머지

--- a/docs/client/progress.index.md
+++ b/docs/client/progress.index.md
@@ -6,6 +6,7 @@
 
 | 날짜       | 주요 작업                            | 상태 |
 | ---------- | ------------------------------------ | ---- |
+| 2026-04-26 | #342 카테고리 전체보기 500 오류 수정 - server route가 client export를 호출하지 않도록 category count helper를 분리하고 public sidebar divider 위치를 보정한 뒤 PR #343 머지 | ✅   |
 | 2026-04-26 | #340 Public sidebar 카테고리 섹션 정리 및 active path auto-expand - 카테고리 섹션 제목/전체보기 액션을 정리하고 category/post 현재 경로만 자동 expand되도록 tree seed를 분리한 뒤 자동 리뷰 warning 1건 보정 후 PR #341 머지 | ✅   |
 | 2026-04-26 | #337 public 비밀글 안내 문구 한글화 - legacy 영어/한국어 secret mask를 모두 인식하고 public 표시 문구를 `비공개입니다.` 로 통일한 뒤 PR #339 머지 | ✅   |
 | 2026-04-26 | #336 public 사이드바 모바일 헤더 겹침 및 데스크톱 border-right 정렬 수정 - 모바일 패널을 헤더 높이 아래로 오프셋하고 데스크톱 sidebar spacing을 `border-right + padding` 구조로 재정렬한 뒤 PR #338 머지 | ✅   |
@@ -105,6 +106,7 @@
 
 ## 🔗 상세 문서
 
+- [progress.2026-04-26.md](./progress/progress.2026-04-26.md) - #342 카테고리 전체보기 500 오류 수정 및 sidebar divider 위치 조정, PR #343 머지
 - [progress.2026-04-26.md](./progress/progress.2026-04-26.md) - #340 Public sidebar 카테고리 섹션 정리 및 active path auto-expand, PR #341 머지
 - [progress.2026-04-26.md](./progress/progress.2026-04-26.md) - #336 public 사이드바 모바일 헤더 겹침 및 데스크톱 border-right 정렬 수정 PR #338 머지
 - [progress.2026-04-25.md](./progress/progress.2026-04-25.md) - #334 Guestbook create type should allow missing guest email PR #335 머지

--- a/docs/client/progress.index.md
+++ b/docs/client/progress.index.md
@@ -6,6 +6,7 @@
 
 | 날짜       | 주요 작업                            | 상태 |
 | ---------- | ------------------------------------ | ---- |
+| 2026-04-26 | #340 Public sidebar 카테고리 섹션 정리 및 active path auto-expand - 카테고리 섹션 제목/전체보기 액션을 정리하고 category/post 현재 경로만 자동 expand되도록 tree seed를 분리한 뒤 자동 리뷰 warning 1건 보정 후 PR #341 머지 | ✅   |
 | 2026-04-26 | #337 public 비밀글 안내 문구 한글화 - legacy 영어/한국어 secret mask를 모두 인식하고 public 표시 문구를 `비공개입니다.` 로 통일한 뒤 PR #339 머지 | ✅   |
 | 2026-04-26 | #336 public 사이드바 모바일 헤더 겹침 및 데스크톱 border-right 정렬 수정 - 모바일 패널을 헤더 높이 아래로 오프셋하고 데스크톱 sidebar spacing을 `border-right + padding` 구조로 재정렬한 뒤 PR #338 머지 | ✅   |
 | 2026-04-25 | #334 Guestbook create type should allow missing guest email - `CreateGuestbookGuestBody.guestEmail`을 optional로 전환하고 PR #335 머지 | ✅   |
@@ -104,6 +105,7 @@
 
 ## 🔗 상세 문서
 
+- [progress.2026-04-26.md](./progress/progress.2026-04-26.md) - #340 Public sidebar 카테고리 섹션 정리 및 active path auto-expand, PR #341 머지
 - [progress.2026-04-26.md](./progress/progress.2026-04-26.md) - #336 public 사이드바 모바일 헤더 겹침 및 데스크톱 border-right 정렬 수정 PR #338 머지
 - [progress.2026-04-25.md](./progress/progress.2026-04-25.md) - #334 Guestbook create type should allow missing guest email PR #335 머지
 - [progress.2026-04-25.md](./progress/progress.2026-04-25.md) - #328 Category 이름 한글 IME 입력 회귀 수정 PR #331 머지

--- a/docs/client/progress.index.md
+++ b/docs/client/progress.index.md
@@ -6,6 +6,7 @@
 
 | 날짜       | 주요 작업                            | 상태 |
 | ---------- | ------------------------------------ | ---- |
+| 2026-04-26 | #349 사이드바 카테고리 트리 leaf 아이템 circle indicator 추가 - public sidebar에서 부모 카테고리는 chevron toggle을 유지하고 leaf 카테고리는 `solar:record-linear` circle marker + direct link row로 구분한 뒤 PR #350 머지 | ✅   |
 | 2026-04-26 | #346 Public 카테고리 내비게이션 UI 정리 - sidebar category label 밀도를 낮추고 leaf marker를 추가했으며 `/categories` overview를 compact list 스타일로 정리하고 category empty state shadow를 제거한 뒤 PR #347 머지 | ✅   |
 | 2026-04-26 | #344 Categories/Tags 헤더 디자인 통일 및 categories 목록/퍼블릭 사이드바 UI 개선 - `/categories`·`/categories/[slug]`·`/tags` 헤더를 shared archive title system으로 통일하고 categories overview item을 card형으로 재구성하며 desktop public sidebar 폭을 `240px`로 보정한 뒤 PR #345 머지 | ✅   |
 | 2026-04-26 | #342 카테고리 전체보기 500 오류 수정 - server route가 client export를 호출하지 않도록 category count helper를 분리하고 public sidebar divider 위치를 보정한 뒤 PR #343 머지 | ✅   |
@@ -108,6 +109,7 @@
 
 ## 🔗 상세 문서
 
+- [progress.2026-04-26.md](./progress/progress.2026-04-26.md) - #349 사이드바 카테고리 트리 leaf 아이템 circle indicator 추가, PR #350 머지
 - [progress.2026-04-26.md](./progress/progress.2026-04-26.md) - #346 Public 카테고리 내비게이션 UI 정리, PR #347 머지
 - [progress.2026-04-26.md](./progress/progress.2026-04-26.md) - #344 Categories/Tags 헤더 디자인 통일 및 categories 목록/퍼블릭 사이드바 UI 개선, PR #345 머지
 - [progress.2026-04-26.md](./progress/progress.2026-04-26.md) - #342 카테고리 전체보기 500 오류 수정 및 sidebar divider 위치 조정, PR #343 머지

--- a/docs/client/progress.index.md
+++ b/docs/client/progress.index.md
@@ -6,6 +6,7 @@
 
 | 날짜       | 주요 작업                            | 상태 |
 | ---------- | ------------------------------------ | ---- |
+| 2026-04-24 | #313 Preview 배포 인덱싱 차단 및 sitemap/robots SEO 점검 - non-production `X-Robots-Tag` 헤더를 middleware에 추가하고, 운영 도메인/비-Vercel production 예외를 보정한 뒤 PR #323 머지 | ✅   |
 | 2026-04-24 | #312 원격 게시글 이미지 호스트 확장 - `api.pyosh.com`과 GitHub/Notion/Naver 계열 호스트를 `next/image` 허용 목록에 추가하고 wildcard 매칭을 Next semantics에 맞춘 뒤 PR #322 머지 | ✅   |
 | 2026-04-24 | #319 헤더에 방명록 네비게이션 링크 추가 - 공개 헤더 액션 영역에 `/guestbook` 링크를 추가하고 PR #321 머지 | ✅   |
 | 2026-04-24 | #318 `/categories` 아카이브 페이지 추가 및 사이드바 전체보기 링크 404 prefetch 해소 - PR #320 머지 | ✅   |
@@ -95,6 +96,7 @@
 
 ## 🔗 상세 문서
 
+- [progress.2026-04-24.md](./progress/progress.2026-04-24.md) - #313 Preview 배포 인덱싱 차단 및 sitemap/robots SEO 점검 PR #323 머지
 - [progress.2026-04-24.md](./progress/progress.2026-04-24.md) - #312 원격 게시글 이미지 호스트 확장 PR #322 머지
 - [progress.2026-04-24.md](./progress/progress.2026-04-24.md) - #319 헤더에 방명록 네비게이션 링크 추가 PR #321 머지
 - [progress.2026-04-24.md](./progress/progress.2026-04-24.md) - #318 `/categories` 아카이브 페이지 추가 및 사이드바 전체보기 링크 404 prefetch 해소 PR #320 머지

--- a/docs/client/progress.index.md
+++ b/docs/client/progress.index.md
@@ -6,6 +6,7 @@
 
 | 날짜       | 주요 작업                            | 상태 |
 | ---------- | ------------------------------------ | ---- |
+| 2026-04-26 | #344 Categories/Tags 헤더 디자인 통일 및 categories 목록/퍼블릭 사이드바 UI 개선 - `/categories`·`/categories/[slug]`·`/tags` 헤더를 shared archive title system으로 통일하고 categories overview item을 card형으로 재구성하며 desktop public sidebar 폭을 `240px`로 보정한 뒤 PR #345 머지 | ✅   |
 | 2026-04-26 | #342 카테고리 전체보기 500 오류 수정 - server route가 client export를 호출하지 않도록 category count helper를 분리하고 public sidebar divider 위치를 보정한 뒤 PR #343 머지 | ✅   |
 | 2026-04-26 | #340 Public sidebar 카테고리 섹션 정리 및 active path auto-expand - 카테고리 섹션 제목/전체보기 액션을 정리하고 category/post 현재 경로만 자동 expand되도록 tree seed를 분리한 뒤 자동 리뷰 warning 1건 보정 후 PR #341 머지 | ✅   |
 | 2026-04-26 | #337 public 비밀글 안내 문구 한글화 - legacy 영어/한국어 secret mask를 모두 인식하고 public 표시 문구를 `비공개입니다.` 로 통일한 뒤 PR #339 머지 | ✅   |
@@ -106,6 +107,7 @@
 
 ## 🔗 상세 문서
 
+- [progress.2026-04-26.md](./progress/progress.2026-04-26.md) - #344 Categories/Tags 헤더 디자인 통일 및 categories 목록/퍼블릭 사이드바 UI 개선, PR #345 머지
 - [progress.2026-04-26.md](./progress/progress.2026-04-26.md) - #342 카테고리 전체보기 500 오류 수정 및 sidebar divider 위치 조정, PR #343 머지
 - [progress.2026-04-26.md](./progress/progress.2026-04-26.md) - #340 Public sidebar 카테고리 섹션 정리 및 active path auto-expand, PR #341 머지
 - [progress.2026-04-26.md](./progress/progress.2026-04-26.md) - #336 public 사이드바 모바일 헤더 겹침 및 데스크톱 border-right 정렬 수정 PR #338 머지

--- a/docs/client/progress/progress.2026-04-24.md
+++ b/docs/client/progress/progress.2026-04-24.md
@@ -1,0 +1,27 @@
+# Client Progress - 2026-04-24
+
+## 완료된 작업
+
+### #318 카테고리 아카이브 페이지 `/categories` 추가 및 사이드바 전체보기 링크 정상화 (PR #320 머지)
+
+공개 레이아웃의 사이드바 `CategoryTree`가 존재하지 않는 `/categories` 경로를 prefetch하면서 홈과 글 상세 등 모든 public 페이지에서 404 로그가 누적되던 문제를 정리했다. 이번 작업에서는 `src/app/(public)/categories/page.tsx`를 추가해 실제 아카이브 라우트를 만들고, 이미 존재하는 `/tags` 아카이브 셸 패턴을 따라 카테고리 전체보기를 노출하도록 맞췄다. 페이지 본문은 기존 `CategoryTree`를 그대로 재사용하되 `showOverviewLink={false}`를 적용해 아카이브 페이지 내부에서 자기 자신을 다시 링크하지 않도록 처리했다. 헤더에는 visible category 개수와 전체 published post 합계를 함께 표시해 카테고리 아카이브라는 의미를 분명히 했다. PR `#320`은 동기 `codex` 리뷰에서 추가 수정 없이 clean 판정을 받고 병합됐다.
+
+**주요 변경 사항:**
+
+- `src/app/(public)/categories/page.tsx`
+  - `/categories` 공개 아카이브 라우트 신규 추가
+  - `fetchCategories()`로 전체 카테고리 트리 조회
+  - visible category node 개수와 `countVisibleCategories()` 기반 공개 글 합계 노출
+  - 기존 `CategoryTree` 재사용, `showOverviewLink={false}` 적용
+  - canonical metadata, empty state, `ScrollToTop` 포함
+
+**검증:**
+
+- `pnpm compile:types`
+- `pnpm lint` *(저장소 기존 warning 2건 유지)*
+- `pnpm build` *(환경 이슈로 실패: `lightningcss.linux-arm64-gnu.node` 누락, 변경분과 무관하게 `/workspace/client`에서도 동일하게 재현)*
+
+**메모:**
+
+- 이 변경으로 public 사이드바의 "분류 전체보기" 링크는 더 이상 존재하지 않는 경로를 prefetch하지 않는다.
+- `pnpm lint` warning 2건은 기존 저장소 상태로, `src/features/post-editor/ui/image-gallery-modal.tsx`의 `<img>` 사용과 `src/shared/ui/error-boundary.tsx`의 미사용 인자다.

--- a/docs/client/progress/progress.2026-04-24.md
+++ b/docs/client/progress/progress.2026-04-24.md
@@ -2,6 +2,28 @@
 
 ## 완료된 작업
 
+### #319 헤더에 방명록 네비게이션 링크 추가 (PR #321 머지)
+
+공개 헤더에 이미 존재하던 `/guestbook` 페이지로 들어갈 수 있는 진입점이 없어 직접 URL 입력 외에는 접근하기 어려웠다. 이번 작업에서는 `src/widgets/header/index.tsx`의 우측 액션 그룹에 방명록 링크를 추가해 검색 아이콘 왼쪽에서 바로 `/guestbook`으로 이동할 수 있게 했다. 별도의 전역 네비게이션을 다시 도입하지 않고 기존 헤더 액션과 동일한 높이와 hover 패턴을 따르는 단일 링크로 정리해 데스크톱과 모바일 모두에서 현재 정렬을 유지했다. PR `#321`은 동기 `codex` 리뷰에서 clean 판정을 받은 뒤 병합됐다.
+
+**주요 변경 사항:**
+
+- `src/widgets/header/index.tsx`
+  - `SearchBar` 앞에 `/guestbook` 링크 추가
+  - 기존 헤더 컨트롤과 같은 `h-9` 높이, 간격, hover 색상 패턴 적용
+  - 공개 헤더에서 모바일/데스크톱 공통으로 방명록 진입 경로 제공
+
+**검증:**
+
+- `pnpm compile:types`
+- `pnpm lint` *(저장소 기존 warning 2건 유지)*
+- `pnpm build`
+
+**메모:**
+
+- `pnpm lint` warning 2건은 기존 저장소 상태로, `src/features/post-editor/ui/image-gallery-modal.tsx`의 `<img>` 사용과 `src/shared/ui/error-boundary.tsx`의 미사용 인자다.
+- 헤더 링크는 별도 메뉴 컴포넌트를 재도입하지 않고 현재 액션 영역 안에서 최소 변경으로 노출했다.
+
 ### #318 카테고리 아카이브 페이지 `/categories` 추가 및 사이드바 전체보기 링크 정상화 (PR #320 머지)
 
 공개 레이아웃의 사이드바 `CategoryTree`가 존재하지 않는 `/categories` 경로를 prefetch하면서 홈과 글 상세 등 모든 public 페이지에서 404 로그가 누적되던 문제를 정리했다. 이번 작업에서는 `src/app/(public)/categories/page.tsx`를 추가해 실제 아카이브 라우트를 만들고, 이미 존재하는 `/tags` 아카이브 셸 패턴을 따라 카테고리 전체보기를 노출하도록 맞췄다. 페이지 본문은 기존 `CategoryTree`를 그대로 재사용하되 `showOverviewLink={false}`를 적용해 아카이브 페이지 내부에서 자기 자신을 다시 링크하지 않도록 처리했다. 헤더에는 visible category 개수와 전체 published post 합계를 함께 표시해 카테고리 아카이브라는 의미를 분명히 했다. PR `#320`은 동기 `codex` 리뷰에서 추가 수정 없이 clean 판정을 받고 병합됐다.
@@ -19,9 +41,8 @@
 
 - `pnpm compile:types`
 - `pnpm lint` *(저장소 기존 warning 2건 유지)*
-- `pnpm build` *(환경 이슈로 실패: `lightningcss.linux-arm64-gnu.node` 누락, 변경분과 무관하게 `/workspace/client`에서도 동일하게 재현)*
+- `pnpm build`
 
 **메모:**
 
-- 이 변경으로 public 사이드바의 "분류 전체보기" 링크는 더 이상 존재하지 않는 경로를 prefetch하지 않는다.
 - `pnpm lint` warning 2건은 기존 저장소 상태로, `src/features/post-editor/ui/image-gallery-modal.tsx`의 `<img>` 사용과 `src/shared/ui/error-boundary.tsx`의 미사용 인자다.

--- a/docs/client/progress/progress.2026-04-24.md
+++ b/docs/client/progress/progress.2026-04-24.md
@@ -2,6 +2,29 @@
 
 ## 완료된 작업
 
+### #313 Preview 배포 인덱싱 차단 및 sitemap/robots SEO 점검 (PR #323 머지)
+
+Preview·staging 배포에서는 `X-Robots-Tag: noindex, nofollow` 헤더를 내려 검색엔진 색인을 막고, 운영 도메인(`pyosh.com`, `www.pyosh.com`)과 일반적인 비-Vercel production 배포는 계속 index 가능하도록 middleware 판별 조건을 정리했다. 함께 `sitemap.xml`과 `robots.txt` 생성 경로를 점검해 `/api` prefix 제거 이후에도 현재 운영 경로 기준으로 이미 올바르게 동작하고 있음을 확인했다. 1차 자동 리뷰에서 non-Vercel production 환경까지 de-index할 수 있다는 warning이 제기돼 hostname + env 기반 조건으로 보정한 뒤 재리뷰 clean 판정 후 PR `#323`이 병합됐다.
+
+**주요 변경 사항:**
+
+- `src/middleware.ts`
+  - non-production 요청에 `X-Robots-Tag: noindex, nofollow` 헤더 추가
+  - 운영 도메인과 비-Vercel production 배포는 de-index 되지 않도록 hostname + env 기반 판별로 보정
+- `src/app/sitemap.ts`, `src/app/robots.ts`
+  - 현재 sitemap/robots 출력이 live 경로를 사용하고 구 `/api` 경로를 참조하지 않음을 검증
+  - 추가 수정은 필요하지 않아 무변경으로 종료
+
+**검증:**
+
+- `pnpm build`
+- `pnpm compile:types`
+- `pnpm lint` *(저장소 기존 warning 2건 유지)*
+
+**메모:**
+
+- `pnpm lint` warning 2건은 기존 저장소 상태로, `src/features/post-editor/ui/image-gallery-modal.tsx`의 `<img>` 사용과 `src/shared/ui/error-boundary.tsx`의 미사용 인자다.
+
 ### #312 원격 게시글 이미지 호스트 확장 및 `next/image` 허용 분기 정합화 (PR #322 머지)
 
 Production에서 `api.pyosh.com`에 저장된 게시글 이미지가 `next/image`의 remote host 검증에 막혀 썸네일과 상세 대표 이미지가 깨지던 문제를 수정했다. 이번 작업에서는 `next.config.js`의 `images.remotePatterns`를 `api.pyosh.com`뿐 아니라 GitHub, Notion, Naver 계열 이미지 호스트까지 확장했고, 같은 허용 목록을 `src/shared/config/remote-image-hosts.json`으로 분리해 `PostCard`의 `supportsNextImage()`도 동일한 규칙을 따르도록 맞췄다. 1차 자동 리뷰에서 wildcard host 매처가 Next.js semantics보다 넓다는 warning이 나와 `**.domain`은 서브도메인만 매치하도록 수정하고, apex가 필요한 Notion 호스트(`www.notion.so`, `www.notion.site`)는 명시적으로 추가한 뒤 재리뷰 clean 판정 후 PR `#322`가 병합됐다.

--- a/docs/client/progress/progress.2026-04-24.md
+++ b/docs/client/progress/progress.2026-04-24.md
@@ -2,6 +2,32 @@
 
 ## 완료된 작업
 
+### #312 원격 게시글 이미지 호스트 확장 및 `next/image` 허용 분기 정합화 (PR #322 머지)
+
+Production에서 `api.pyosh.com`에 저장된 게시글 이미지가 `next/image`의 remote host 검증에 막혀 썸네일과 상세 대표 이미지가 깨지던 문제를 수정했다. 이번 작업에서는 `next.config.js`의 `images.remotePatterns`를 `api.pyosh.com`뿐 아니라 GitHub, Notion, Naver 계열 이미지 호스트까지 확장했고, 같은 허용 목록을 `src/shared/config/remote-image-hosts.json`으로 분리해 `PostCard`의 `supportsNextImage()`도 동일한 규칙을 따르도록 맞췄다. 1차 자동 리뷰에서 wildcard host 매처가 Next.js semantics보다 넓다는 warning이 나와 `**.domain`은 서브도메인만 매치하도록 수정하고, apex가 필요한 Notion 호스트(`www.notion.so`, `www.notion.site`)는 명시적으로 추가한 뒤 재리뷰 clean 판정 후 PR `#322`가 병합됐다.
+
+**주요 변경 사항:**
+
+- `next.config.js`
+  - 로컬 `localhost:5500` 외에 production API 및 외부 이미지 호스트 패턴을 shared JSON에서 로드하도록 변경
+- `src/shared/config/remote-image-hosts.json`
+  - `api.pyosh.com`, `github.com`, `**.githubusercontent.com`, Notion, Naver 계열 허용 호스트 정의
+- `src/features/post-list/ui/post-card.tsx`
+  - 카드 썸네일의 `next/image` 사용 여부가 Next 설정과 동일한 host 매칭 규칙을 따르도록 정리
+- `README.md`
+  - 기본 원격 이미지 호스트 지원 범위 문서화
+
+**검증:**
+
+- `pnpm compile:types`
+- `pnpm lint` *(저장소 기존 warning 2건 유지)*
+- `pnpm build`
+
+**메모:**
+
+- `pnpm lint` warning 2건은 기존 저장소 상태로, `src/features/post-editor/ui/image-gallery-modal.tsx`의 `<img>` 사용과 `src/shared/ui/error-boundary.tsx`의 미사용 인자다.
+- 자동 리뷰 warning 반영으로 wildcard host 매칭은 Next.js `remotePatterns` semantics와 동일하게 유지된다.
+
 ### #319 헤더에 방명록 네비게이션 링크 추가 (PR #321 머지)
 
 공개 헤더에 이미 존재하던 `/guestbook` 페이지로 들어갈 수 있는 진입점이 없어 직접 URL 입력 외에는 접근하기 어려웠다. 이번 작업에서는 `src/widgets/header/index.tsx`의 우측 액션 그룹에 방명록 링크를 추가해 검색 아이콘 왼쪽에서 바로 `/guestbook`으로 이동할 수 있게 했다. 별도의 전역 네비게이션을 다시 도입하지 않고 기존 헤더 액션과 동일한 높이와 hover 패턴을 따르는 단일 링크로 정리해 데스크톱과 모바일 모두에서 현재 정렬을 유지했다. PR `#321`은 동기 `codex` 리뷰에서 clean 판정을 받은 뒤 병합됐다.

--- a/docs/client/progress/progress.2026-04-25.md
+++ b/docs/client/progress/progress.2026-04-25.md
@@ -2,6 +2,30 @@
 
 ## 완료된 작업
 
+### #329 Public post list item 링크 구조 정리 (PR #330 머지)
+
+public post list item이 `article` 내부에서 절대 위치 `Link` overlay와 실제 view 컨테이너가 형제 관계로 배치돼 있던 구조를 정리했다. 이번 수정에서는 overlay anchor를 제거하고, `Link`가 썸네일/메타/제목/요약을 포함한 실제 item view를 직접 감싸도록 마크업을 바꿨다. 바깥 `article`은 기존처럼 hover shift와 배경 hover shell로 유지하고, 기존 패딩과 클릭 영역은 `Link`로 옮겨 시각 구조와 DOM 의미론을 일치시켰다. PR `#330`은 동기 `codex` 리뷰 후 clean 판정으로 병합됐다.
+
+**주요 변경 사항:**
+
+- `src/features/post-list/ui/post-list-item.tsx`
+  - 절대 위치 overlay `Link` 제거
+  - `Link`가 실제 item view wrapper가 되도록 구조 변경
+  - 기존 `px-4 py-5 sm:px-5` 클릭 영역을 `Link`로 이동
+  - `article`의 hover animation/background 동작은 유지
+
+**검증:**
+
+- `pnpm install --frozen-lockfile`
+- `pnpm compile:types`
+- `pnpm lint` *(저장소 기존 warning 2건 유지)*
+- `pnpm build`
+
+**메모:**
+
+- `pnpm lint` warning은 기존 항목인 `src/features/post-editor/ui/image-gallery-modal.tsx`의 `<img>` 사용과 `src/shared/ui/error-boundary.tsx`의 `_error` 미사용 2건만 남았다.
+- issue worktree에는 의존성이 없어서 verify 전에 `pnpm install --frozen-lockfile`로 worktree 전용 `node_modules`를 구성했다.
+
 ### #326 Category/Tag 한글 slug 라우트 404 + Category 입력 한글 IME 분해 버그 수정 (PR #327 머지)
 
 카테고리/태그 공개 페이지가 한글 slug 직링크에서 404를 내고, 관리자 카테고리 모달의 이름 입력이 한글 IME 사용 시 자모 분해 형태로 남던 문제를 한 번에 정리했다. 이번 수정에서는 게시글 상세 slug 조회에서 이미 검증된 decode fallback + Unicode 정규화 패턴을 category/tag 경로에도 공통으로 적용하도록 `shared` slug 유틸을 추가했다. category slug lookup은 저장된 slug와 route param을 같은 기준으로 비교하도록 바꿨고, tag 페이지는 active tag 판별뿐 아니라 posts fetch에 넘기는 `tagSlug`도 정규화된 값으로 통일했다. 또한 카테고리 이름 입력은 composition 중간값을 그대로 두되, 합성이 끝나는 시점과 submit 직전에 NFC로 다시 정규화해 저장 시 `에이아이` 같은 합성형 문자열이 유지되도록 했다. PR `#327`은 동기 `codex` 리뷰 후 clean 판정으로 병합됐다.

--- a/docs/client/progress/progress.2026-04-25.md
+++ b/docs/client/progress/progress.2026-04-25.md
@@ -1,0 +1,37 @@
+# Client Progress - 2026-04-25
+
+## 완료된 작업
+
+### #324 휴지통/관리자 화면에서 카테고리 NULL 글 표시 및 복원 UX 정리 (PR #325 머지)
+
+카테고리 삭제 후 휴지통으로 이동한 글이 `categoryId/category = null` 상태로 내려올 수 있도록 서버가 바뀐 뒤, 클라이언트 관리 화면이 여전히 `post.category.name`을 직접 참조하던 문제를 정리했다. 이번 작업에서는 관리자 post 엔티티 타입에서 `categoryId`와 `category`를 nullable로 전환하고, 휴지통 및 관리자 목록에서 orphan 글을 `(카테고리 없음)`으로 표시하도록 수정했다. 또한 휴지통에서 복원할 때 카테고리 없는 글은 즉시 복원하지 않고 먼저 카테고리 선택 모달을 띄워 재지정 후 복원하도록 바꿨다. 단건 복원과 벌크 복원 모두 같은 규칙을 적용했고, public 단건 상세와 구조화 데이터도 nullable category를 방어하도록 정리했다. PR `#325`는 동기 `codex` 리뷰 후 suggestion 없이 clean 판정으로 병합됐다.
+
+**주요 변경 사항:**
+
+- `src/entities/post/model.ts`
+  - 관리자 post 타입의 `categoryId`를 `number | null`로 전환
+  - `PostListItem.category`, `PostDetail.category`를 nullable로 전환
+  - `PublishedPostListItem`은 public 경로 계약 유지를 위해 non-null category로 유지
+- `src/app/manage/posts/page.tsx`
+  - 카테고리 없는 글 복원 시 카테고리 선택 모달을 먼저 띄우는 restore flow 추가
+  - 선택한 카테고리를 orphan 글에 먼저 patch한 뒤 restore를 실행하도록 단건/벌크 복원 경로 통합
+- `src/widgets/admin-post-list/ui/post-table.tsx`
+  - 휴지통/관리자 목록에서 null category를 `(카테고리 없음)`으로 표시
+- `src/app/(public)/posts/[slug]/page.tsx`
+  - breadcrumb, related posts 조회, 카테고리 badge 렌더를 optional access로 방어
+- `src/shared/lib/structured-data.ts`
+  - JSON-LD `articleSection` 생성 시 nullable category를 허용
+- `src/features/category-manager/ui/category-delete-modal.tsx`
+  - "휴지통 이동" 설명에 복원 시 카테고리 재지정이 필요하다는 안내 추가
+
+**검증:**
+
+- `pnpm install --frozen-lockfile`
+- `pnpm compile:types`
+- `pnpm lint` *(저장소 기존 warning 2건 유지)*
+- `pnpm build`
+
+**메모:**
+
+- `pnpm lint` warning은 기존 항목인 `src/features/post-editor/ui/image-gallery-modal.tsx`의 `<img>` 사용과 `src/shared/ui/error-boundary.tsx`의 `_error` 미사용 2건만 남았다.
+- issue worktree에는 의존성이 없어서 verify 전에 `pnpm install --frozen-lockfile`로 worktree 전용 `node_modules`를 구성했다.

--- a/docs/client/progress/progress.2026-04-25.md
+++ b/docs/client/progress/progress.2026-04-25.md
@@ -2,6 +2,39 @@
 
 ## 완료된 작업
 
+### #326 Category/Tag 한글 slug 라우트 404 + Category 입력 한글 IME 분해 버그 수정 (PR #327 머지)
+
+카테고리/태그 공개 페이지가 한글 slug 직링크에서 404를 내고, 관리자 카테고리 모달의 이름 입력이 한글 IME 사용 시 자모 분해 형태로 남던 문제를 한 번에 정리했다. 이번 수정에서는 게시글 상세 slug 조회에서 이미 검증된 decode fallback + Unicode 정규화 패턴을 category/tag 경로에도 공통으로 적용하도록 `shared` slug 유틸을 추가했다. category slug lookup은 저장된 slug와 route param을 같은 기준으로 비교하도록 바꿨고, tag 페이지는 active tag 판별뿐 아니라 posts fetch에 넘기는 `tagSlug`도 정규화된 값으로 통일했다. 또한 카테고리 이름 입력은 composition 중간값을 그대로 두되, 합성이 끝나는 시점과 submit 직전에 NFC로 다시 정규화해 저장 시 `에이아이` 같은 합성형 문자열이 유지되도록 했다. PR `#327`은 동기 `codex` 리뷰 후 clean 판정으로 병합됐다.
+
+**주요 변경 사항:**
+
+- `src/shared/lib/slug.ts`
+  - slug decode/normalize/encode 공통 helper 추가
+  - route param 비교와 API path 생성이 같은 Unicode 정규화 기준을 사용하도록 통일
+- `src/entities/post/api.ts`
+  - `fetchPostBySlug()`가 shared slug helper를 사용하도록 정리
+  - 기존 decode fallback 동작은 유지하면서 path builder 중복 제거
+- `src/entities/category/lib.ts`
+  - `findCategoryBySlug()`가 route slug를 decode + `NFKC` 정규화한 뒤 재귀 탐색하도록 변경
+- `src/app/(public)/tags/[slug]/page.tsx`
+  - tag route param을 정규화한 값으로 `fetchPosts({ tagSlug })`를 호출
+  - active tag 판별도 저장된 tag slug 정규화 후 비교
+- `src/features/category-manager/ui/category-form-modal.tsx`
+  - category name input에 composition state 추가
+  - composition 종료 시점과 submit 시점에 `NFC` 정규화 적용
+
+**검증:**
+
+- `CI=true pnpm install --offline`
+- `pnpm compile:types`
+- `pnpm lint` *(저장소 기존 warning 2건 유지)*
+- `pnpm build`
+
+**메모:**
+
+- `pnpm lint` warning은 기존 항목인 `src/features/post-editor/ui/image-gallery-modal.tsx`의 `<img>` 사용과 `src/shared/ui/error-boundary.tsx`의 `_error` 미사용 2건만 남았다.
+- issue worktree에는 의존성이 없어서 verify 전에 worktree-local `node_modules`를 다시 구성했다.
+
 ### #324 휴지통/관리자 화면에서 카테고리 NULL 글 표시 및 복원 UX 정리 (PR #325 머지)
 
 카테고리 삭제 후 휴지통으로 이동한 글이 `categoryId/category = null` 상태로 내려올 수 있도록 서버가 바뀐 뒤, 클라이언트 관리 화면이 여전히 `post.category.name`을 직접 참조하던 문제를 정리했다. 이번 작업에서는 관리자 post 엔티티 타입에서 `categoryId`와 `category`를 nullable로 전환하고, 휴지통 및 관리자 목록에서 orphan 글을 `(카테고리 없음)`으로 표시하도록 수정했다. 또한 휴지통에서 복원할 때 카테고리 없는 글은 즉시 복원하지 않고 먼저 카테고리 선택 모달을 띄워 재지정 후 복원하도록 바꿨다. 단건 복원과 벌크 복원 모두 같은 규칙을 적용했고, public 단건 상세와 구조화 데이터도 nullable category를 방어하도록 정리했다. PR `#325`는 동기 `codex` 리뷰 후 suggestion 없이 clean 판정으로 병합됐다.

--- a/docs/client/progress/progress.2026-04-25.md
+++ b/docs/client/progress/progress.2026-04-25.md
@@ -2,6 +2,21 @@
 
 ## 완료된 작업
 
+### #334 Guestbook create type should allow missing guest email (PR #335 머지)
+
+게스트북 생성 타입이 `guestEmail`을 필수로 강제하던 클라이언트 계약을 서버/API 동작과 맞췄다. 이번 변경에서는 `CreateGuestbookGuestBody`의 `guestEmail`을 optional로 전환해, 이메일 없이 작성 가능한 guestbook 입력 흐름과 타입 정의가 동일한 계약을 갖도록 정리했다. PR `#335`는 동기 `codex` 리뷰 1라운드 후 clean 판정으로 병합됐다.
+
+**주요 변경 사항:**
+
+- `src/entities/guestbook/model.ts`
+  - `CreateGuestbookGuestBody.guestEmail`을 `string`에서 `string | undefined` 성격의 optional 필드로 변경
+  - guestbook 작성 폼과 API payload가 이메일 없는 guest 작성도 타입 수준에서 허용하도록 정렬
+
+**검증:**
+
+- 동기 `codex` PR 리뷰 1라운드
+- 리뷰 결과: `0 critical / 0 warning / 0 suggestion`
+
 ### #332 카테고리 관리 모달 한글 IME 조합 끊김 수정 (PR #333 머지)
 
 카테고리 관리 모달의 이름 input에서 한글 IME 조합 중 자모 분리나 첫 글자 유실이 발생하던 문제를 수정했다. 직접 원인은 category input 자체보다 공용 `Modal`의 포커스 관리였다. `CategoryFormModal`이 매 렌더마다 새 `onClose` 함수를 `Modal`에 전달했고, `Modal`의 포커스 트랩 effect가 `[isOpen, onClose]`에 의존하면서 입력 중에도 cleanup과 재실행이 반복됐다. 그 cleanup에서 이전 활성 요소로 포커스를 돌리는 로직이 한글 조합 중간에 개입해 IME가 끊기고 있었다. 이번 수정에서는 `Modal`이 최신 `onClose`를 ref로 읽도록 바꾸고, 초기 포커스와 keydown 핸들러는 `isOpen` 기준으로만 설치되게 정리했다. 포커스 복원은 실제 모달 닫힘 전환에서만 실행되도록 분리했고, 카테고리 폼의 modal close handler도 `useCallback`으로 안정화했다. PR `#333`은 동기 `codex` 리뷰 1라운드 후 clean 판정으로 병합됐다.

--- a/docs/client/progress/progress.2026-04-25.md
+++ b/docs/client/progress/progress.2026-04-25.md
@@ -2,6 +2,32 @@
 
 ## 완료된 작업
 
+### #332 카테고리 관리 모달 한글 IME 조합 끊김 수정 (PR #333 머지)
+
+카테고리 관리 모달의 이름 input에서 한글 IME 조합 중 자모 분리나 첫 글자 유실이 발생하던 문제를 수정했다. 직접 원인은 category input 자체보다 공용 `Modal`의 포커스 관리였다. `CategoryFormModal`이 매 렌더마다 새 `onClose` 함수를 `Modal`에 전달했고, `Modal`의 포커스 트랩 effect가 `[isOpen, onClose]`에 의존하면서 입력 중에도 cleanup과 재실행이 반복됐다. 그 cleanup에서 이전 활성 요소로 포커스를 돌리는 로직이 한글 조합 중간에 개입해 IME가 끊기고 있었다. 이번 수정에서는 `Modal`이 최신 `onClose`를 ref로 읽도록 바꾸고, 초기 포커스와 keydown 핸들러는 `isOpen` 기준으로만 설치되게 정리했다. 포커스 복원은 실제 모달 닫힘 전환에서만 실행되도록 분리했고, 카테고리 폼의 modal close handler도 `useCallback`으로 안정화했다. PR `#333`은 동기 `codex` 리뷰 1라운드 후 clean 판정으로 병합됐다.
+
+**주요 변경 사항:**
+
+- `src/shared/ui/libs/modal.tsx`
+  - 최신 `onClose`를 ref로 유지해 포커스 트랩 effect dependency에서 제거
+  - 모달 open 시에만 초기 포커스와 ESC/Tab keydown 핸들러를 설치
+  - 포커스 복원은 effect cleanup이 아니라 실제 close transition에서만 실행되도록 분리
+- `src/features/category-manager/ui/category-form-modal.tsx`
+  - modal에 전달하는 `onClose`를 `useCallback`으로 안정화
+  - submit 중 close 차단 동작은 유지
+
+**검증:**
+
+- `pnpm install --frozen-lockfile`
+- `pnpm compile:types`
+- `pnpm lint` *(저장소 기존 warning 2건 유지)*
+- `pnpm build`
+
+**메모:**
+
+- `pnpm lint` warning은 기존 항목인 `src/features/post-editor/ui/image-gallery-modal.tsx`의 `<img>` 사용과 `src/shared/ui/error-boundary.tsx`의 `_error` 미사용 2건만 남았다.
+- issue worktree에는 의존성이 없어 verify 전에 `pnpm install --frozen-lockfile`로 worktree 전용 `node_modules`를 구성했다.
+
 ### #328 Category 이름 한글 IME 입력 시 manage error boundary 트립 회귀 수정 (PR #331 머지)
 
 관리자 카테고리 모달에서 한글 IME 입력 중 화면이 `/manage/error.tsx` fallback으로 전환되던 회귀를 수정했다. 원인은 PR #327에서 추가한 composition 처리 패턴에 있었다. 카테고리 이름 입력이 `useState` 기반 composing 플래그에 의존하면서 `onChange` 클로저가 직전 렌더 상태를 참조했고, 동시에 composition 중 controlled input 값을 재기입하는 흐름이 섞여 있었다. 이번 수정에서는 ref 기반으로 composition 상태를 추적하는 `useImeSafeText()` 훅을 추가하고, composing 중에는 raw value를 그대로 state에 반영해 입력 표시를 유지하면서 transform은 일반 입력과 composition 종료 시점에만 적용하도록 정리했다. 같은 stale pattern이 있던 태그 입력도 함께 같은 훅으로 전환했다. PR `#331`은 동기 `codex` 리뷰 2라운드 후 clean 판정으로 머지됐다.

--- a/docs/client/progress/progress.2026-04-25.md
+++ b/docs/client/progress/progress.2026-04-25.md
@@ -2,6 +2,37 @@
 
 ## 완료된 작업
 
+### #328 Category 이름 한글 IME 입력 시 manage error boundary 트립 회귀 수정 (PR #331 머지)
+
+관리자 카테고리 모달에서 한글 IME 입력 중 화면이 `/manage/error.tsx` fallback으로 전환되던 회귀를 수정했다. 원인은 PR #327에서 추가한 composition 처리 패턴에 있었다. 카테고리 이름 입력이 `useState` 기반 composing 플래그에 의존하면서 `onChange` 클로저가 직전 렌더 상태를 참조했고, 동시에 composition 중 controlled input 값을 재기입하는 흐름이 섞여 있었다. 이번 수정에서는 ref 기반으로 composition 상태를 추적하는 `useImeSafeText()` 훅을 추가하고, composing 중에는 raw value를 그대로 state에 반영해 입력 표시를 유지하면서 transform은 일반 입력과 composition 종료 시점에만 적용하도록 정리했다. 같은 stale pattern이 있던 태그 입력도 함께 같은 훅으로 전환했다. PR `#331`은 동기 `codex` 리뷰 2라운드 후 clean 판정으로 머지됐다.
+
+**주요 변경 사항:**
+
+- `src/shared/hooks/use-ime-safe-text.ts`
+  - ref 기반 IME-safe text hook 추가
+  - composition 중에는 raw value를 유지하고, 일반 입력/`compositionend`에서는 caller transform을 적용
+  - 모달 reopen 등 중간 종료 상황을 위한 composition reset 제공
+- `src/features/category-manager/ui/category-form-modal.tsx`
+  - 카테고리 이름 입력을 shared hook으로 전환
+  - stale composing state 제거
+  - NFC normalize를 commit 시점에만 적용
+- `src/features/post-editor/ui/tag-chip-input.tsx`
+  - 태그 입력의 composition 추적도 shared hook으로 통일
+  - Enter/blur guard는 ref 기반 composing 상태를 직접 참조하도록 변경
+
+**검증:**
+
+- `pnpm install --offline --frozen-lockfile`
+- `pnpm compile:types`
+- `pnpm lint` *(저장소 기존 warning 2건 유지)*
+- `pnpm build`
+
+**메모:**
+
+- `pnpm lint` warning 2건은 기존 이슈로 유지됐다.
+- `src/features/post-editor/ui/image-gallery-modal.tsx`의 `<img>` 사용 warning 1건
+- `src/shared/ui/error-boundary.tsx`의 `_error` 미사용 warning 1건
+
 ### #329 Public post list item 링크 구조 정리 (PR #330 머지)
 
 public post list item이 `article` 내부에서 절대 위치 `Link` overlay와 실제 view 컨테이너가 형제 관계로 배치돼 있던 구조를 정리했다. 이번 수정에서는 overlay anchor를 제거하고, `Link`가 썸네일/메타/제목/요약을 포함한 실제 item view를 직접 감싸도록 마크업을 바꿨다. 바깥 `article`은 기존처럼 hover shift와 배경 hover shell로 유지하고, 기존 패딩과 클릭 영역은 `Link`로 옮겨 시각 구조와 DOM 의미론을 일치시켰다. PR `#330`은 동기 `codex` 리뷰 후 clean 판정으로 병합됐다.

--- a/docs/client/progress/progress.2026-04-26.md
+++ b/docs/client/progress/progress.2026-04-26.md
@@ -2,32 +2,28 @@
 
 ## 완료된 작업
 
-### #336 public 사이드바 모바일 헤더 겹침 및 데스크톱 border-right 정렬 수정 (PR #338 머지)
+### #337 public 비밀글 안내 문구 한글화 (PR #339 머지)
 
-public 레이아웃의 모바일 슬라이드 인 사이드바가 고정 헤더 아래에서 시작하지 않아 패널 상단 콘텐츠가 헤더와 겹치던 문제를 수정했다. 동시에 데스크톱 public 사이드바는 기존 `gap + pr` 기반 간격 구조를 정리하고 실제 `border-right` 구분선을 자연스럽게 배치하도록 레이아웃 spacing을 재배치했다. 이번 수정에서는 헤더가 측정한 실제 높이를 CSS 변수로 노출하고, `SlideInPanel`이 선택적으로 상단 오프셋을 받을 수 있게 해 public 모바일 패널이 헤더 높이를 그대로 따르도록 맞췄다. PR `#338`은 동기 `codex` 리뷰 1라운드 후 clean 판정으로 병합됐다.
+public 댓글 비밀글이 영어 문구 `This comment is secret.` 으로 노출되던 문제를 client 이슈 `#337` 기준으로 정리했다. 클라이언트 코드 검색 결과 비밀글 마스크 판별은 `src/features/comment-section/ui/comment-list.tsx` 한 곳에서만 이뤄지고 있었고, 여기서는 한국어 sentinel `비공개 메시지입니다` 만 비밀글 마스크로 취급하고 있었다. 이번 수정으로 legacy 영어/한국어 마스크 문자열은 모두 비밀글로 인식하되, 실제 사용자 표시 문구는 항상 `비공개입니다.` 로 통일했다.
+
+자동 리뷰 1차에서는 새 표시 문구 자체를 sentinel alias에 포함하면 실제 댓글 본문과 충돌할 수 있다는 suggestion이 나왔다. 이에 따라 판별 alias는 기존에 알려진 영어/이전 한국어 마스크만 유지하고, 렌더링 시에만 새 문구 `비공개입니다.` 를 사용하도록 보정했다. 재리뷰 후 clean 판정으로 PR `#339`를 머지했다.
 
 **주요 변경 사항:**
 
-- `src/shared/ui/libs/slide-in-panel.tsx`
-  - 슬라이드 인 패널에 선택적 `topOffset` prop 추가
-  - 상단 오프셋이 필요한 패널이 기존 caller를 깨지 않고 고정 헤더 아래에서 시작할 수 있게 정리
-- `src/widgets/header/index.tsx`
-  - 측정된 헤더 높이를 `--site-header-height` CSS 변수로 노출
-  - public 모바일 사이드바가 실제 헤더 높이를 그대로 참조하도록 연결
-- `src/app/(public)/layout-shell.tsx`
-  - 모바일 public 사이드바 패널에 헤더 높이 기반 `topOffset` 전달
-  - 데스크톱 sidebar/main 간격 구조를 `gap` 중심에서 `border-right + padding` 구조로 재배치
+- `src/features/comment-section/ui/comment-list.tsx`
+  - 비밀글 표시 문구를 `비공개입니다.` 로 통일
+  - legacy 영어 마스크 `This comment is secret.` 지원 추가
+  - 이전 한국어 마스크 `비공개 메시지입니다` 도 계속 지원
+  - 표시 문구와 비밀글 판별 sentinel을 분리해 실제 댓글 본문과의 충돌 가능성 축소
 
 **검증:**
 
-- `pnpm install`
-- `pnpm compile:types`
+- `pnpm install --frozen-lockfile`
 - `pnpm lint` *(저장소 기존 warning 2건 유지)*
 - `pnpm build`
-- 동기 `codex` PR 리뷰 1라운드
-- 리뷰 결과: `0 critical / 0 warning / 0 suggestion`
+- `pnpm compile:types`
 
 **메모:**
 
-- `pnpm lint` warning은 기존 항목인 `src/features/post-editor/ui/image-gallery-modal.tsx`의 `<img>` 사용과 `src/shared/ui/error-boundary.tsx`의 `_error` 미사용 2건만 남았다.
-- issue worktree에는 의존성이 없어 verify 전에 worktree-local `pnpm install`이 필요했다.
+- client 코드 기준 동일 런타임 판별 지점은 `comment-list.tsx` 한 곳뿐이었다.
+- `pnpm lint`는 저장소 기존 warning인 `src/features/post-editor/ui/image-gallery-modal.tsx`의 `<img>` 사용 1건과 `src/shared/ui/error-boundary.tsx`의 `_error` 미사용 1건만 남았다.

--- a/docs/client/progress/progress.2026-04-26.md
+++ b/docs/client/progress/progress.2026-04-26.md
@@ -2,6 +2,34 @@
 
 ## 완료된 작업
 
+### #352 public category tree spacing/icon 후속 보정 (PR #355 머지)
+
+같은 이슈 `#352`에서 sidebar와 `/categories` category tree에 남아 있던 spacing 회귀를 한 번 더 정리했다. 직전 보정 이후 toggle slot이 `20px` 기준으로 다시 조여지면서 chevron이 작아 보이고, sidebar row도 wireframe보다 낮아져 title/icon이 다소 빽빽하게 붙어 있었다. 이번 라운드에서는 `CategoryTree` 구조는 그대로 유지한 채 control slot, row padding, depth indent만 다시 보정해 시각 밀도를 wireframe 쪽으로 되돌리는 데 집중했다.
+
+sidebar 쪽은 toggle/icon slot을 `24px`로 키우고 link row를 `py-2` 기준으로 넉넉하게 다시 잡아, 사용자가 기준으로 준 `padding-top: 8px` 수준의 vertical rhythm과 비슷한 정렬감을 맞췄다. `/categories` overview도 같은 `24px` control slot을 쓰도록 맞춰 toggle icon 축소 회귀를 제거했고, child category indent step을 더 크게 잡아 top-level parent 바로 아래 자식이 한 칸 tab된 것처럼 읽히도록 조정했다. count는 이전 라운드에서 만든 fixed right column 구조를 유지해 모든 item이 같은 x-position에 남도록 했다.
+
+이번 PR은 동기 `codex` 리뷰 1라운드 clean 판정으로 추가 resolve 없이 바로 머지됐다.
+
+**주요 변경 사항:**
+
+- `src/features/category-tree/ui/category-tree.tsx`
+  - sidebar/overview 공통 control slot을 `24px`로 키워 toggle icon 축소 회귀 보정
+  - sidebar와 overview child row의 vertical padding을 다시 늘려 wireframe에 가까운 item height 복구
+  - overview child indentation step을 확대해 immediate child가 한 칸 tab된 계층감으로 보이도록 조정
+  - 기존 fixed right count column 정렬은 유지
+
+**검증:**
+
+- `pnpm install --frozen-lockfile`
+- `pnpm compile:types`
+- `pnpm lint` *(저장소 기존 warning 2건 유지)*
+- `pnpm build`
+
+**메모:**
+
+- `pnpm lint`는 기존 warning인 `src/features/post-editor/ui/image-gallery-modal.tsx`의 `<img>` 사용 1건과 `src/shared/ui/error-boundary.tsx`의 `_error` 미사용 1건만 남았다.
+- 자동 리뷰는 `0 critical / 0 warning / 0 suggestion` clean 판정이었다.
+
 ### #352 public category tree 정렬/고정 count column 후속 보정 (PR #354 머지)
 
 PR `#353` 머지 후 남아 있던 시각 정렬 문제를 같은 이슈 `#352`에서 한 번 더 보정했다. 이번 변경은 구조를 다시 크게 뒤엎지 않고 `CategoryTree` row contract만 정리하는 쪽으로 좁혔다. sidebar 쪽은 icon slot과 title/count row를 `items-center` 기준으로 다시 맞추고 title line-height를 `1.2`로 낮춰, 8px dot indicator와 텍스트가 실제 시각상 중앙에 맞도록 보정했다. `/categories` overview 쪽은 top-level category title만 요청값대로 `1.0625rem` / `700`으로 올리고, depth indentation이 오른쪽 count 위치를 흔들지 않도록 indent를 icon/content 측에만 남기고 count는 고정 right column으로 분리했다.

--- a/docs/client/progress/progress.2026-04-26.md
+++ b/docs/client/progress/progress.2026-04-26.md
@@ -2,6 +2,32 @@
 
 ## 완료된 작업
 
+### #349 사이드바 카테고리 트리 leaf 아이템 circle indicator 추가 (PR #350 머지)
+
+public sidebar category tree에서 부모 category와 leaf category가 같은 row 구조를 써서 계층 정보가 흐려지던 문제를 정리했다. 구현 기준은 root repo wireframe `docs/client/designs/public/home-page-sidebar.html`의 category section이었고, 요구사항대로 부모 category는 기존 chevron toggle과 expand/collapse 동작을 그대로 유지하면서 leaf category만 direct link row로 분기했다. leaf row는 별도 chevron spacer를 두지 않고 `solar:record-linear` 아이콘을 label 앞에 배치해, 자식이 없는 항목이라는 신호를 더 직접적으로 주도록 맞췄다.
+
+이번 수정은 sidebar variant에만 한정했고 `/categories` overview variant의 compact card/list 표현은 그대로 유지했다. 따라서 홈, 태그 목록, category detail, post detail 등 public sidebar를 공유하는 화면들은 같은 개선을 받되 categories index 자체의 정보 구조는 건드리지 않았다. 동기 `codex` 리뷰는 1라운드 clean 판정이었고 PR `#350`으로 바로 머지됐다.
+
+**주요 변경 사항:**
+
+- `src/features/category-tree/ui/category-tree.tsx`
+  - sidebar leaf category를 전용 direct link row로 분기
+  - leaf marker로 `solar:record-linear` 아이콘을 추가
+  - 부모 category의 chevron toggle/expand state 로직은 유지
+  - overview variant는 기존 compact list/card 표현을 그대로 유지
+
+**검증:**
+
+- `pnpm install --frozen-lockfile`
+- `pnpm compile:types`
+- `pnpm lint` *(저장소 기존 warning 2건 유지)*
+- `pnpm build`
+
+**메모:**
+
+- `pnpm lint`는 기존 warning인 `src/features/post-editor/ui/image-gallery-modal.tsx`의 `<img>` 사용 1건과 `src/shared/ui/error-boundary.tsx`의 `_error` 미사용 1건만 남았다.
+- 자동 리뷰는 suggestion 없이 clean이어서 resolve 라운드 없이 바로 머지됐다.
+
 ### #346 Public 카테고리 내비게이션 UI 정리 (PR #347 머지)
 
 최근 category overview와 public sidebar 개선 이후 커진 category row 표현을 다시 compact한 public navigation 톤으로 조정했다. `CategoryTree`의 sidebar variant에서는 label weight와 vertical padding을 낮추고, 자식이 없는 category도 기존 blank spacer 대신 `aria-hidden` leaf marker를 같은 width slot 안에 렌더링해 chevron이 있는 항목과 정렬을 유지했다. Chevron toggle의 hit area와 expand/collapse 동작은 그대로 유지했다.

--- a/docs/client/progress/progress.2026-04-26.md
+++ b/docs/client/progress/progress.2026-04-26.md
@@ -2,6 +2,37 @@
 
 ## 완료된 작업
 
+### #342 카테고리 전체보기 500 오류 및 public 사이드바 구분선 위치 조정 (PR #343 머지)
+
+`/categories` 전체보기 페이지가 서버 렌더링 중 500으로 실패하던 문제를 수정했다. 원인은 server component인 `src/app/(public)/categories/page.tsx`가 `"use client"` 모듈인 `CategoryTree` 파일에서 함께 export된 `countVisibleCategories()`를 직접 호출하고 있던 점이었다. 이 함수는 public 사이드바처럼 client component 안에서는 문제없었지만, 서버 라우트에서는 client export를 실행할 수 없어 카테고리 전체보기 진입 시 런타임 오류로 이어졌다. 수정은 순수 재귀 count 로직을 `src/features/category-tree/lib/category-counts.ts`로 분리해 server/client 양쪽에서 공용으로 쓰도록 정리하는 방향으로 진행했다.
+
+동시에 이슈에 포함된 UI 요구사항에 맞춰 desktop public sidebar의 약한 구분선을 `aside` 외곽이 아니라 내부 wrapper에 적용하도록 레이아웃을 조정했다. 자동 리뷰 1차에서는 divider를 안쪽으로 옮긴 뒤 outer `pr-8`을 그대로 둬 gutter가 두 배로 벌어지는 warning이 나왔고, follow-up 커밋에서 outer padding을 제거해 폭 회귀 없이 구분선 위치만 바뀌도록 마무리했다. PR `#343`은 동기 `codex` 리뷰 2라운드 후 clean 판정으로 병합됐다.
+
+**주요 변경 사항:**
+
+- `src/features/category-tree/lib/category-counts.ts`
+  - visible category node 수와 published post 수를 세는 순수 helper를 분리
+- `src/features/category-tree/index.ts`
+  - counting helper를 client component export와 분리해 re-export
+- `src/features/category-tree/ui/category-tree.tsx`
+  - overview count 계산을 공용 helper로 통일
+- `src/app/(public)/categories/page.tsx`
+  - server route가 client module 함수를 직접 호출하지 않도록 정리
+- `src/app/(public)/layout-shell.tsx`
+  - desktop sidebar divider를 inner wrapper에 적용하고 중복 gutter 제거
+
+**검증:**
+
+- `pnpm install --frozen-lockfile`
+- `pnpm compile:types`
+- `pnpm lint` *(저장소 기존 warning 2건 유지)*
+- `pnpm build`
+
+**메모:**
+
+- `pnpm lint`는 저장소 기존 warning인 `src/features/post-editor/ui/image-gallery-modal.tsx`의 `<img>` 사용 1건과 `src/shared/ui/error-boundary.tsx`의 `_error` 미사용 1건만 남았다.
+- 최초 구현 커밋 `c5ae16e` 뒤 자동 리뷰 warning 1건을 반영해 `d7c1fd1`로 divider spacing을 보정했고, 이후 재리뷰 clean으로 병합했다.
+
 ### #340 Public sidebar 카테고리 섹션 정리 및 active path auto-expand (PR #341 머지)
 
 public sidebar의 category 섹션을 카테고리 탐색 중심 흐름으로 정리했다. 섹션 제목을 `카테고리 (N)`으로 단축하고 `/categories`로 이동하는 `전체보기` 액션을 추가했으며, category tree는 기본적으로 모두 접힌 상태에서 시작하도록 바꿨다. `/categories/[slug]`와 `/posts/[slug]`에서는 현재 카테고리 경로만 자동으로 펼쳐지도록 route별 sidebar seed 데이터를 내려 보내고, tree 내부에서는 그 seed를 초기 상태로만 사용해 사용자가 직접 토글한 이후 상태를 같은 렌더링 흐름에서 덮어쓰지 않도록 분리했다.

--- a/docs/client/progress/progress.2026-04-26.md
+++ b/docs/client/progress/progress.2026-04-26.md
@@ -2,6 +2,39 @@
 
 ## 완료된 작업
 
+### #340 Public sidebar 카테고리 섹션 정리 및 active path auto-expand (PR #341 머지)
+
+public sidebar의 category 섹션을 카테고리 탐색 중심 흐름으로 정리했다. 섹션 제목을 `카테고리 (N)`으로 단축하고 `/categories`로 이동하는 `전체보기` 액션을 추가했으며, category tree는 기본적으로 모두 접힌 상태에서 시작하도록 바꿨다. `/categories/[slug]`와 `/posts/[slug]`에서는 현재 카테고리 경로만 자동으로 펼쳐지도록 route별 sidebar seed 데이터를 내려 보내고, tree 내부에서는 그 seed를 초기 상태로만 사용해 사용자가 직접 토글한 이후 상태를 같은 렌더링 흐름에서 덮어쓰지 않도록 분리했다.
+
+자동 리뷰 1차에서는 `CategoryTree`의 `initialExpandedSlugs = []` 기본값이 prop 생략 호출자에서 무한 렌더 루프를 만들 수 있다는 warning이 나왔다. 이에 따라 안정적인 module-level 빈 배열 fallback으로 수정하고, 다시 `compile:types`, `lint`, `build`를 확인한 뒤 재리뷰 clean 판정으로 PR `#341`를 머지했다.
+
+**주요 변경 사항:**
+
+- `src/widgets/public-sidebar/ui/public-sidebar.tsx`
+  - category 섹션 제목을 `카테고리 (N)`으로 변경
+  - `/categories`로 이동하는 `전체보기` 액션 추가
+  - post/category page에서 주입한 sidebar category path JSON을 읽어 tree 초기 확장 slug를 계산
+- `src/features/category-tree/ui/category-tree.tsx`
+  - 토글 상태를 item local state에서 tree root state로 승격
+  - route seed 기반 `initialExpandedSlugs` 지원
+  - prop 생략 시 무한 렌더를 막는 stable empty fallback 추가
+- `src/app/(public)/posts/[slug]/page.tsx`
+  - 현재 글 category path slug를 sidebar용 JSON script로 주입
+- `src/app/(public)/categories/[slug]/page.tsx`
+  - 현재 category path slug를 sidebar용 JSON script로 주입
+
+**검증:**
+
+- `pnpm install`
+- `pnpm build`
+- `pnpm compile:types`
+- `pnpm lint` *(저장소 기존 warning 2건 유지)*
+
+**메모:**
+
+- `pnpm compile:types`는 이 저장소의 `.next/types` 포함 규칙 때문에 `pnpm build` 완료 후 순차 실행했다.
+- 남아 있는 lint warning 2건은 기존 이슈와 동일하게 `src/features/post-editor/ui/image-gallery-modal.tsx`의 `<img>` 사용과 `src/shared/ui/error-boundary.tsx`의 `_error` 미사용이다.
+
 ### #337 public 비밀글 안내 문구 한글화 (PR #339 머지)
 
 public 댓글 비밀글이 영어 문구 `This comment is secret.` 으로 노출되던 문제를 client 이슈 `#337` 기준으로 정리했다. 클라이언트 코드 검색 결과 비밀글 마스크 판별은 `src/features/comment-section/ui/comment-list.tsx` 한 곳에서만 이뤄지고 있었고, 여기서는 한국어 sentinel `비공개 메시지입니다` 만 비밀글 마스크로 취급하고 있었다. 이번 수정으로 legacy 영어/한국어 마스크 문자열은 모두 비밀글로 인식하되, 실제 사용자 표시 문구는 항상 `비공개입니다.` 로 통일했다.

--- a/docs/client/progress/progress.2026-04-26.md
+++ b/docs/client/progress/progress.2026-04-26.md
@@ -1,0 +1,33 @@
+# Client Progress - 2026-04-26
+
+## 완료된 작업
+
+### #336 public 사이드바 모바일 헤더 겹침 및 데스크톱 border-right 정렬 수정 (PR #338 머지)
+
+public 레이아웃의 모바일 슬라이드 인 사이드바가 고정 헤더 아래에서 시작하지 않아 패널 상단 콘텐츠가 헤더와 겹치던 문제를 수정했다. 동시에 데스크톱 public 사이드바는 기존 `gap + pr` 기반 간격 구조를 정리하고 실제 `border-right` 구분선을 자연스럽게 배치하도록 레이아웃 spacing을 재배치했다. 이번 수정에서는 헤더가 측정한 실제 높이를 CSS 변수로 노출하고, `SlideInPanel`이 선택적으로 상단 오프셋을 받을 수 있게 해 public 모바일 패널이 헤더 높이를 그대로 따르도록 맞췄다. PR `#338`은 동기 `codex` 리뷰 1라운드 후 clean 판정으로 병합됐다.
+
+**주요 변경 사항:**
+
+- `src/shared/ui/libs/slide-in-panel.tsx`
+  - 슬라이드 인 패널에 선택적 `topOffset` prop 추가
+  - 상단 오프셋이 필요한 패널이 기존 caller를 깨지 않고 고정 헤더 아래에서 시작할 수 있게 정리
+- `src/widgets/header/index.tsx`
+  - 측정된 헤더 높이를 `--site-header-height` CSS 변수로 노출
+  - public 모바일 사이드바가 실제 헤더 높이를 그대로 참조하도록 연결
+- `src/app/(public)/layout-shell.tsx`
+  - 모바일 public 사이드바 패널에 헤더 높이 기반 `topOffset` 전달
+  - 데스크톱 sidebar/main 간격 구조를 `gap` 중심에서 `border-right + padding` 구조로 재배치
+
+**검증:**
+
+- `pnpm install`
+- `pnpm compile:types`
+- `pnpm lint` *(저장소 기존 warning 2건 유지)*
+- `pnpm build`
+- 동기 `codex` PR 리뷰 1라운드
+- 리뷰 결과: `0 critical / 0 warning / 0 suggestion`
+
+**메모:**
+
+- `pnpm lint` warning은 기존 항목인 `src/features/post-editor/ui/image-gallery-modal.tsx`의 `<img>` 사용과 `src/shared/ui/error-boundary.tsx`의 `_error` 미사용 2건만 남았다.
+- issue worktree에는 의존성이 없어 verify 전에 worktree-local `pnpm install`이 필요했다.

--- a/docs/client/progress/progress.2026-04-26.md
+++ b/docs/client/progress/progress.2026-04-26.md
@@ -2,6 +2,33 @@
 
 ## 완료된 작업
 
+### #352 public category tree 정렬/고정 count column 후속 보정 (PR #354 머지)
+
+PR `#353` 머지 후 남아 있던 시각 정렬 문제를 같은 이슈 `#352`에서 한 번 더 보정했다. 이번 변경은 구조를 다시 크게 뒤엎지 않고 `CategoryTree` row contract만 정리하는 쪽으로 좁혔다. sidebar 쪽은 icon slot과 title/count row를 `items-center` 기준으로 다시 맞추고 title line-height를 `1.2`로 낮춰, 8px dot indicator와 텍스트가 실제 시각상 중앙에 맞도록 보정했다. `/categories` overview 쪽은 top-level category title만 요청값대로 `1.0625rem` / `700`으로 올리고, depth indentation이 오른쪽 count 위치를 흔들지 않도록 indent를 icon/content 측에만 남기고 count는 고정 right column으로 분리했다.
+
+동기 `codex` 리뷰 1차 결과는 suggestion 1건뿐이었고, 내용은 hover color inheritance 회귀였다. `titleClassName`이 자식 span에 직접 text color를 주면서 link의 `hover:text-primary-1` 피드백이 title에 전파되지 않던 문제라, span의 base color를 제거해 hover 상속을 복구했다. suggestion-only라 `resolve-skip` 경로로 보정 후 PR `#354`를 머지했다.
+
+**주요 변경 사항:**
+
+- `src/features/category-tree/ui/category-tree.tsx`
+  - sidebar/overview row를 고정 `count` column이 있는 grid 구조로 재정렬
+  - icon slot과 title/count row를 `items-center` 기준으로 맞추고 title line-height를 `1.2`로 조정
+  - `/categories` top-level title만 `1.0625rem` / `700` 적용
+  - overview nested wrapper의 폭 감소(`ml/pl`)를 제거해 모든 item의 count x-position을 동일하게 고정
+  - review suggestion 반영: title span의 직접 text color를 제거해 link hover color 상속 복구
+
+**검증:**
+
+- `pnpm install --frozen-lockfile`
+- `pnpm compile:types`
+- `pnpm lint` *(저장소 기존 warning 2건 유지)*
+- `pnpm build`
+
+**메모:**
+
+- `pnpm lint`는 기존 warning인 `src/features/post-editor/ui/image-gallery-modal.tsx`의 `<img>` 사용 1건과 `src/shared/ui/error-boundary.tsx`의 `_error` 미사용 1건만 남았다.
+- 자동 리뷰는 `0 critical / 0 warning / 1 suggestion`이었고, hover color inheritance만 보정한 뒤 `skipReview=true`로 머지됐다.
+
 ### #352 Sidebar 카테고리 UI 재디자인 보정 (PR #353 머지)
 
 최근 public category tree redesign 이후 wireframe과 어긋난 sidebar/categories UI를 보정했다. sidebar leaf category는 부모 toggle과 같은 left slot 안에 8px dot indicator를 두도록 row 구조를 다시 맞춰, 아이콘 위치와 텍스트 간격이 일관되게 정렬되도록 수정했다. `/categories` overview는 top-level count badge의 배경/rounding을 제거하고 title/count typography를 wireframe 밀도에 맞게 낮췄으며, overview 전용 렌더링을 root group + leaf 분기 대신 재귀 `CategoryItem` 기반으로 다시 정리해 중첩 child category도 toggle 가능한 구조로 통합했다.

--- a/docs/client/progress/progress.2026-04-26.md
+++ b/docs/client/progress/progress.2026-04-26.md
@@ -2,6 +2,38 @@
 
 ## 완료된 작업
 
+### #344 Categories/Tags 헤더 디자인 통일 및 categories 목록/퍼블릭 사이드바 UI 개선 (PR #345 머지)
+
+`/categories`, `/categories/[slug]`, `/tags`의 공개 아카이브 헤더 시각 언어를 하나의 shared component 체계로 정리했다. 기존에는 `/categories/[slug]`만 `ArchiveHeader`를 사용하고 `/categories`, `/tags`는 별도 header markup을 유지하고 있어 title scale, eyebrow, 메타 카운트 배치가 서로 달랐다. 이번 작업에서는 `ArchiveHeader`가 페이지별로 다른 summary와 eyebrow를 받을 수 있도록 일반화하고, `/categories`의 제목을 요구사항대로 `Categories`로 변경해 세 라우트가 같은 구조의 타이틀 시스템을 공유하도록 맞췄다.
+
+동시에 `/categories` 목록에서 쓰는 `CategoryTree`에 overview 전용 표현을 추가해 각 category row가 border, surface, count chip을 가진 카드형 항목으로 보이도록 재구성했다. sidebar에서 쓰는 compact tree 표현은 그대로 유지하고, overview route에서만 더 강한 항목 경계와 depth 가이드를 적용했다. public sidebar는 직전 border-right 추가로 좁아진 desktop 폭을 `234px -> 240px`로 소폭 확장해 내부 gutter가 다시 답답해 보이지 않도록 보정했다. 동기 `codex` 리뷰는 1라운드 clean 판정이었고 PR `#345`로 머지됐다.
+
+**주요 변경 사항:**
+
+- `src/shared/ui/libs/archive-header.tsx`
+  - archive header가 page별 eyebrow/summary를 받을 수 있도록 일반화
+- `src/app/(public)/categories/page.tsx`
+  - `/categories` 제목을 `Categories`로 변경
+  - shared archive header를 적용하고 category directory summary를 표시
+- `src/app/(public)/tags/page.tsx`
+  - `/tags`에 shared archive header를 적용하고 tag count summary를 표시
+- `src/features/category-tree/ui/category-tree.tsx`
+  - overview variant를 추가해 categories index에서 card형 항목, count chip, nested depth guide를 사용
+  - sidebar에서는 기존 compact variant를 유지
+- `src/app/(public)/layout-shell.tsx`
+  - desktop public sidebar width를 `240px`로 확장
+
+**검증:**
+
+- `pnpm compile:types`
+- `pnpm lint` *(저장소 기존 warning 2건 유지)*
+- `pnpm build`
+
+**메모:**
+
+- `pnpm lint`는 기존 warning인 `src/features/post-editor/ui/image-gallery-modal.tsx`의 `<img>` 사용 1건과 `src/shared/ui/error-boundary.tsx`의 `_error` 미사용 1건만 남았다.
+- 자동 리뷰는 suggestion 없이 clean이어서 추가 resolve 라운드 없이 바로 머지됐다.
+
 ### #342 카테고리 전체보기 500 오류 및 public 사이드바 구분선 위치 조정 (PR #343 머지)
 
 `/categories` 전체보기 페이지가 서버 렌더링 중 500으로 실패하던 문제를 수정했다. 원인은 server component인 `src/app/(public)/categories/page.tsx`가 `"use client"` 모듈인 `CategoryTree` 파일에서 함께 export된 `countVisibleCategories()`를 직접 호출하고 있던 점이었다. 이 함수는 public 사이드바처럼 client component 안에서는 문제없었지만, 서버 라우트에서는 client export를 실행할 수 없어 카테고리 전체보기 진입 시 런타임 오류로 이어졌다. 수정은 순수 재귀 count 로직을 `src/features/category-tree/lib/category-counts.ts`로 분리해 server/client 양쪽에서 공용으로 쓰도록 정리하는 방향으로 진행했다.

--- a/docs/client/progress/progress.2026-04-26.md
+++ b/docs/client/progress/progress.2026-04-26.md
@@ -2,6 +2,37 @@
 
 ## 완료된 작업
 
+### #352 Sidebar 카테고리 UI 재디자인 보정 (PR #353 머지)
+
+최근 public category tree redesign 이후 wireframe과 어긋난 sidebar/categories UI를 보정했다. sidebar leaf category는 부모 toggle과 같은 left slot 안에 8px dot indicator를 두도록 row 구조를 다시 맞춰, 아이콘 위치와 텍스트 간격이 일관되게 정렬되도록 수정했다. `/categories` overview는 top-level count badge의 배경/rounding을 제거하고 title/count typography를 wireframe 밀도에 맞게 낮췄으며, overview 전용 렌더링을 root group + leaf 분기 대신 재귀 `CategoryItem` 기반으로 다시 정리해 중첩 child category도 toggle 가능한 구조로 통합했다.
+
+동시에 Storybook mock category tree에 손자 depth를 추가하고 public `CategoryTree` 전용 story를 만들어 sidebar/overview 둘 다 회귀를 바로 확인할 수 있게 했다. 동기 `codex` 리뷰 1차에서는 recursive overview 도입 후 `getDefaultExpandedSlugs()`와 `모두 펼치기`가 root slug만 수집해 nested expandable group이 기본 확장/expand-all 대상에서 빠지는 warning 1건이 나왔고, visible descendant 전체를 재귀 수집하도록 보정한 뒤 2차 clean 판정으로 PR `#353`이 머지됐다.
+
+**주요 변경 사항:**
+
+- `src/features/category-tree/ui/category-tree.tsx`
+  - sidebar leaf row를 toggle slot 기준으로 재정렬하고 8px dot indicator 적용
+  - category title/count typography를 wireframe 밀도로 조정
+  - overview count badge의 background/radius 제거
+  - overview tree를 재귀 `CategoryItem` 구조로 통합해 nested child group toggle 지원
+  - overview 기본 확장 slug와 `모두 펼치기` 대상을 visible descendant 전체로 재귀 수집
+- `stories/mocks/data/categories.ts`
+  - count 값과 손자 depth mock category를 추가해 overview nested toggle 회귀를 재현 가능하게 정리
+- `stories/features/category-tree.stories.tsx`
+  - public category tree의 sidebar/overview variant를 직접 확인하는 Storybook story 추가
+
+**검증:**
+
+- `pnpm install --frozen-lockfile`
+- `pnpm compile:types`
+- `pnpm lint` *(저장소 기존 warning 2건 유지)*
+- `pnpm build`
+
+**메모:**
+
+- `pnpm lint`는 기존 warning인 `src/features/post-editor/ui/image-gallery-modal.tsx`의 `<img>` 사용 1건과 `src/shared/ui/error-boundary.tsx`의 `_error` 미사용 1건만 남았다.
+- issue worktree에는 verify용 의존성이 없어 `pnpm install --frozen-lockfile`로 worktree-local `node_modules`를 먼저 구성했다.
+
 ### #348 `/categories` 페이지 재디자인 - 컴팩트 트리 레이아웃 (PR #351 머지)
 
 `/categories` 페이지를 root repo wireframe `docs/client/designs/public/categories.html` 기준의 compact tree archive로 다시 구현했다. 기존 gradient/card 중심 overview를 걷어내고, `ArchiveHeader`는 그대로 유지하면서 제목을 `카테고리`로 맞추고 우측 summary를 `총 N개 분류`로 단순화했다. 본문에는 2칸 stat strip을 추가해 분류 수와 공개 글 수만 남기고, category overview는 top-level group + leaf 구조의 전용 compact tree로 분리했다.

--- a/docs/client/progress/progress.2026-04-26.md
+++ b/docs/client/progress/progress.2026-04-26.md
@@ -2,6 +2,35 @@
 
 ## 완료된 작업
 
+### #346 Public 카테고리 내비게이션 UI 정리 (PR #347 머지)
+
+최근 category overview와 public sidebar 개선 이후 커진 category row 표현을 다시 compact한 public navigation 톤으로 조정했다. `CategoryTree`의 sidebar variant에서는 label weight와 vertical padding을 낮추고, 자식이 없는 category도 기존 blank spacer 대신 `aria-hidden` leaf marker를 같은 width slot 안에 렌더링해 chevron이 있는 항목과 정렬을 유지했다. Chevron toggle의 hit area와 expand/collapse 동작은 그대로 유지했다.
+
+`/categories` overview variant는 큰 rounded card와 row shadow를 제거하고 얇은 border, left rail, muted surface, count pill 중심의 compact list item으로 재정리했다. `/categories/[slug]`에서 글이 없는 category empty state는 shared `EmptyState` variant를 바꾸지 않고 해당 route와 Storybook preview에서만 `shadow-none`을 넘겨 public layout과 맞췄다. 동기 `codex` 리뷰는 1라운드 clean 판정이었고 PR `#347`로 머지됐다.
+
+**주요 변경 사항:**
+
+- `src/features/category-tree/ui/category-tree.tsx`
+  - sidebar label weight/padding을 줄여 category tree 밀도를 보정
+  - leaf category에 non-interactive `aria-hidden` marker 추가
+  - overview variant를 shadow 없는 compact bordered list item으로 재정리
+- `src/app/(public)/categories/[slug]/page.tsx`
+  - category page empty state에 한정해 box shadow 제거
+- `stories/app/category-posts.stories.tsx`
+  - category posts empty Storybook preview에 동일한 no-shadow 표현 반영
+
+**검증:**
+
+- `pnpm install --frozen-lockfile`
+- `pnpm compile:types`
+- `pnpm lint` *(저장소 기존 warning 2건 유지)*
+- `pnpm build`
+
+**메모:**
+
+- `pnpm lint`는 기존 warning인 `src/features/post-editor/ui/image-gallery-modal.tsx`의 `<img>` 사용 1건과 `src/shared/ui/error-boundary.tsx`의 `_error` 미사용 1건만 남았다.
+- 자동 리뷰는 suggestion 없이 clean이어서 resolve 라운드 없이 바로 머지됐다.
+
 ### #344 Categories/Tags 헤더 디자인 통일 및 categories 목록/퍼블릭 사이드바 UI 개선 (PR #345 머지)
 
 `/categories`, `/categories/[slug]`, `/tags`의 공개 아카이브 헤더 시각 언어를 하나의 shared component 체계로 정리했다. 기존에는 `/categories/[slug]`만 `ArchiveHeader`를 사용하고 `/categories`, `/tags`는 별도 header markup을 유지하고 있어 title scale, eyebrow, 메타 카운트 배치가 서로 달랐다. 이번 작업에서는 `ArchiveHeader`가 페이지별로 다른 summary와 eyebrow를 받을 수 있도록 일반화하고, `/categories`의 제목을 요구사항대로 `Categories`로 변경해 세 라우트가 같은 구조의 타이틀 시스템을 공유하도록 맞췄다.

--- a/docs/client/progress/progress.2026-04-26.md
+++ b/docs/client/progress/progress.2026-04-26.md
@@ -2,6 +2,36 @@
 
 ## 완료된 작업
 
+### #348 `/categories` 페이지 재디자인 - 컴팩트 트리 레이아웃 (PR #351 머지)
+
+`/categories` 페이지를 root repo wireframe `docs/client/designs/public/categories.html` 기준의 compact tree archive로 다시 구현했다. 기존 gradient/card 중심 overview를 걷어내고, `ArchiveHeader`는 그대로 유지하면서 제목을 `카테고리`로 맞추고 우측 summary를 `총 N개 분류`로 단순화했다. 본문에는 2칸 stat strip을 추가해 분류 수와 공개 글 수만 남기고, category overview는 top-level group + leaf 구조의 전용 compact tree로 분리했다.
+
+구현은 `CategoryTree`의 sidebar variant와 overview variant를 명확히 분리하는 방향으로 정리했다. sidebar 쪽은 직전 PR #350에서 들어간 leaf row 개선을 유지했고, overview 쪽에만 전체 펼치기/접기, 상위 3개 그룹 기본 확장, muted count pill, compact leaf indentation을 넣었다. 동기 `codex` 리뷰 1차에서는 collapsed group의 hidden link가 tab order에 남는 접근성 warning 1건이 나왔고, child panel을 closed state에서 비노출/비상호작용 상태로 바꿔 재리뷰 clean 판정 후 PR `#351`이 머지됐다.
+
+**주요 변경 사항:**
+
+- `src/app/(public)/categories/page.tsx`
+  - header title을 `카테고리`로 조정하고 summary를 `총 N개 분류`로 단순화
+  - 2칸 stat strip으로 `분류` / `공개 글` 핵심 수치만 노출
+- `src/features/category-tree/ui/category-tree.tsx`
+  - overview variant 전용 compact tree UI 추가
+  - top-level group toggle, `모두 펼치기` / `모두 접기`, 상위 3개 기본 확장 구현
+  - public sidebar leaf row 개선(`solar:record-linear`)과 overview redesign을 같은 파일에서 병합
+  - collapsed overview panel의 descendant link를 tab order에서 제거
+
+**검증:**
+
+- `pnpm install --offline --frozen-lockfile`
+- `pnpm build`
+- `pnpm compile:types`
+- `pnpm lint` *(저장소 기존 warning 2건 유지)*
+
+**메모:**
+
+- `pnpm compile:types`는 이 저장소의 `.next/types` 포함 규칙 때문에 `pnpm build` 완료 후 순차 실행했다.
+- `pnpm lint`는 기존 warning인 `src/features/post-editor/ui/image-gallery-modal.tsx`의 `<img>` 사용 1건과 `src/shared/ui/error-boundary.tsx`의 `_error` 미사용 1건만 남았다.
+- merge 단계에서 `origin/main`의 PR #350 leaf row 변경과 충돌이 발생해, compact overview 변경과 leaf marker 변경을 한 파일에서 재통합한 뒤 정상 머지했다.
+
 ### #349 사이드바 카테고리 트리 leaf 아이템 circle indicator 추가 (PR #350 머지)
 
 public sidebar category tree에서 부모 category와 leaf category가 같은 row 구조를 써서 계층 정보가 흐려지던 문제를 정리했다. 구현 기준은 root repo wireframe `docs/client/designs/public/home-page-sidebar.html`의 category section이었고, 요구사항대로 부모 category는 기존 chevron toggle과 expand/collapse 동작을 그대로 유지하면서 leaf category만 direct link row로 분기했다. leaf row는 별도 chevron spacer를 두지 않고 `solar:record-linear` 아이콘을 label 앞에 배치해, 자식이 없는 항목이라는 신호를 더 직접적으로 주도록 맞췄다.

--- a/docs/client/progress/progress.2026-04-27.md
+++ b/docs/client/progress/progress.2026-04-27.md
@@ -1,0 +1,31 @@
+# Progress: 2026-04-27
+
+## Completed
+
+- [x] #352 public category tree renderer를 sidebar 전용 view와 `/categories` overview 전용 view로 분리
+- [x] Sidebar category tree의 row height, toggle icon slot, text/icon vertical alignment, hover border behavior를 sidebar 요구사항 기준으로 정리
+- [x] `/categories` overview tree의 top-level title typography, fixed count column, icon/title/count vertical alignment, child indentation, Link-hover row background behavior를 overview 요구사항 기준으로 정리
+- [x] `/categories` page Storybook story를 추가하고 기존 category-tree story가 명시적인 sidebar/overview 컴포넌트를 렌더링하도록 갱신
+- [x] 전체 변경사항을 단일 커밋 `8106e6f`로 정리하고 PR #356 생성
+
+## Discoveries
+
+- 기존 `CategoryTree`는 `variant`/`isOverview` 계열 조건으로 sidebar와 `/categories` 화면을 동시에 처리해, 한쪽 UI 수정이 다른 화면의 spacing, icon size, row height에 영향을 주기 쉬운 구조였다.
+- 렌더링 view는 분리하되 visible tree 계산과 expanded slug state는 `lib`로 추출해 공유하면 UI 결합을 줄이면서 동작 로직 중복은 피할 수 있다.
+
+## Issues & Resolutions
+
+- **Issue**: `pnpm build`가 로컬 `node_modules`의 `lightningcss` optional native package 누락으로 실패했다.
+- **Resolution**: `CI=true pnpm install --force --frozen-lockfile`로 lockfile을 유지한 채 native optional dependency를 복구한 뒤 `pnpm build`를 통과시켰다.
+- **Issue**: Storybook typecheck에는 기존 `Post` export mismatch 오류가 남아 있었다.
+- **Resolution**: 새 `/categories` story 자체의 타입 오류는 발생하지 않았고, 별도 기존 Storybook typing 이슈로 분리해서 볼 수 있도록 기록했다.
+
+## Verification
+
+- [x] `pnpm compile:types`
+- [x] `pnpm lint`
+- [x] `pnpm build`
+
+## Next Steps
+
+- [ ] PR #356 merge 후 Issue #352 close 상태 확인

--- a/docs/client/progress/progress.2026-04-29.md
+++ b/docs/client/progress/progress.2026-04-29.md
@@ -2,19 +2,24 @@
 
 ## Completed
 
+- [x] #360 관리자 카테고리 일괄 선택 모드에 삭제 액션을 추가하고 PR #362 머지
 - [x] #359 관리자 카테고리 배치 편집에서 3-depth 하위 노드를 상위 부모로 이동할 때 중간 노드가 working tree UI에서 사라지는 문제를 수정하고 PR #361 머지
 
 ## Discoveries
 
+- 카테고리 벌크 삭제 서버 계약은 `DELETE /categories/bulk` + JSON body `{ ids, action, moveTo? }`이며, 단건 삭제와 동일한 move/trash 정책을 클라이언트에서 먼저 안내해야 한다.
 - `removeCategory()`는 대상의 직접 부모 `children` 배열을 `splice()`로 이미 갱신하므로, 재귀 복귀 중 `result.tree`를 상위 조상의 `children`에 다시 대입하면 조상 트리 구조가 손상된다.
 
 ## Issues & Resolutions
 
+- **Issue**: 일괄 선택 하단 액션 바에 선택한 카테고리를 한 번에 삭제하는 액션이 없고, 글이 있거나 하위 카테고리가 있는 선택 조합을 안전하게 처리할 UI가 없음
+- **Resolution**: `deleteCategories(ids, options)` API helper를 추가하고, 선택 모드 삭제 버튼 + 벌크 삭제 모달을 연결해 하위 카테고리 포함 시 차단, 글 포함 시 move/trash 선택, 이동 대상에서 삭제 대상을 제외하도록 구현
 - **Issue**: `테스트1 > 테스트2 > 테스트3`에서 `테스트3`을 `테스트1`의 자식으로 이동하면 재귀 복귀 중 `테스트1.children`이 `테스트2.children` 결과로 덮여 `테스트2`가 UI에서 누락됨
 - **Resolution**: `removeCategory()` 반환값을 제거된 카테고리만 담도록 축소하고, 상위 재귀 호출에서 직접 부모의 child list를 조상에게 재대입하지 않도록 정리
 
 ## Verification
 
+- #360: `pnpm compile:types`, `pnpm lint` (기존 warning 2건 유지), `pnpm build`, 자동 리뷰 clean
 - `node --experimental-strip-types` one-off fixture: 3-depth inside 이동, cross-level before 이동, 동일 부모 before 이동, `calculateTreeChanges()` 결과 확인
 - `pnpm compile:types`
 - `pnpm lint` (기존 warning 2건 유지)

--- a/docs/client/progress/progress.2026-04-29.md
+++ b/docs/client/progress/progress.2026-04-29.md
@@ -1,0 +1,21 @@
+# Progress: 2026-04-29
+
+## Completed
+
+- [x] #359 관리자 카테고리 배치 편집에서 3-depth 하위 노드를 상위 부모로 이동할 때 중간 노드가 working tree UI에서 사라지는 문제를 수정하고 PR #361 머지
+
+## Discoveries
+
+- `removeCategory()`는 대상의 직접 부모 `children` 배열을 `splice()`로 이미 갱신하므로, 재귀 복귀 중 `result.tree`를 상위 조상의 `children`에 다시 대입하면 조상 트리 구조가 손상된다.
+
+## Issues & Resolutions
+
+- **Issue**: `테스트1 > 테스트2 > 테스트3`에서 `테스트3`을 `테스트1`의 자식으로 이동하면 재귀 복귀 중 `테스트1.children`이 `테스트2.children` 결과로 덮여 `테스트2`가 UI에서 누락됨
+- **Resolution**: `removeCategory()` 반환값을 제거된 카테고리만 담도록 축소하고, 상위 재귀 호출에서 직접 부모의 child list를 조상에게 재대입하지 않도록 정리
+
+## Verification
+
+- `node --experimental-strip-types` one-off fixture: 3-depth inside 이동, cross-level before 이동, 동일 부모 before 이동, `calculateTreeChanges()` 결과 확인
+- `pnpm compile:types`
+- `pnpm lint` (기존 warning 2건 유지)
+- `pnpm build`

--- a/docs/server/findings.index.md
+++ b/docs/server/findings.index.md
@@ -22,6 +22,7 @@
 | 014 | 게시글 검색 전략 (MySQL LIKE)                         | 2026-02-22 | #search #mysql #like #drizzle |
 | 015 | Guestbook + settings API (Issue #35)                  | 2026-03-26 | #guestbook #settings #drizzle #http-semantics #soft-delete |
 | 016 | Categories API (Issue #34)                            | 2026-03-26 | #categories #drizzle #toctou #tree #migration |
+| 017 | Trusted Proxy — Docker 네트워크 서브넷 고정           | 2026-04-24 | #trusted-proxy #docker #cloudflared #session-cookie #deployment |
 
 ## 🔗 상세 문서
 
@@ -41,6 +42,7 @@
 - [findings.014-post-search-strategy.md](./findings/findings.014-post-search-strategy.md) - 게시글 검색 전략 (MySQL LIKE)
 - [findings.015-guestbook-settings-api.md](./findings/findings.015-guestbook-settings-api.md) - Guestbook + settings API 설계 (Issue #35)
 - [findings.016-categories-api.md](./findings/findings.016-categories-api.md) - Categories API 설계 (Issue #34)
+- [findings.017-trusted-proxy-docker-subnet.md](./findings/findings.017-trusted-proxy-docker-subnet.md) - Trusted Proxy Docker 네트워크 서브넷 고정 (Issue #108)
 
 ## 📊 요약
 

--- a/docs/server/findings/findings.017-trusted-proxy-docker-subnet.md
+++ b/docs/server/findings/findings.017-trusted-proxy-docker-subnet.md
@@ -1,0 +1,68 @@
+# Findings 017: Trusted Proxy — Docker 네트워크 서브넷 고정
+
+**날짜**: 2026-04-24
+**태그**: #trusted-proxy #docker #cloudflared #session-cookie #deployment
+**관련 Issue**: #108
+
+## 📝 요약
+
+`TRUSTED_PROXY_RANGES`에 cloudflared 컨테이너의 특정 IP를 단일 값으로 넣으면,
+Docker 네트워크가 재생성될 때마다 IP가 바뀌어 trusted proxy 체크를 통과하지 못한다.
+서브넷 CIDR 전체를 고정 값으로 등록하면 IP 변동에 강건해진다.
+
+## 🎯 증상 및 원인
+
+### 증상
+
+배포 환경에서 관리자 로그인은 200을 반환하지만 세션 쿠키가 브라우저에 저장되지 않아 즉시 로그아웃 상태가 된다. (PR #106/#107, v1.1.1에서 첫 발생 후 수정; v1.1.2에서 재발 방지)
+
+### 연쇄 구조
+
+```
+cloudflared IP 변경
+  → isTrustedProxyPeer(remoteAddress) === false   (src/app.ts:112)
+    → onRequest 훅이 X-Forwarded-Proto 헤더 삭제  (src/app.ts:134-147)
+      → Fastify가 요청을 HTTP로 간주
+        → session cookie에 Secure 속성 미부여
+          → 브라우저가 HTTPS 페이지에서 쿠키 수신 거부
+            → /auth/me 인증 실패 → 로그인 실패
+```
+
+### 근본 원인
+
+`blog_network`가 `external: true`로 선언되어 있어 `docker network create` 시 서브넷을 명시하지 않으면 Docker가 임의 대역을 할당한다. 네트워크 재생성 시 서브넷과 컨테이너 IP가 달라지므로, 이전에 `.env`에 기록한 단일 IP 값이 맞지 않는다.
+
+## 🔧 해결 방법
+
+### 네트워크 서브넷 고정
+
+```bash
+docker network create --driver bridge --subnet 172.28.0.0/24 blog_network
+```
+
+재생성 전 서브넷 확인:
+```bash
+docker network inspect blog_network --format '{{range .IPAM.Config}}{{.Subnet}}{{end}}'
+```
+
+### TRUSTED_PROXY_RANGES를 서브넷 CIDR로 지정
+
+```
+# .env (production)
+TRUSTED_PROXY_RANGES=172.28.0.0/24
+```
+
+단일 IP(`172.x.x.x/32`)가 아닌 서브넷 전체를 지정하면 Docker가 컨테이너에 할당하는 IP가 바뀌어도 재발하지 않는다.
+
+## ⚠️ 주의: `external: true`의 의미
+
+Docker Compose의 `external: true`는 "이 네트워크는 compose 바깥에서 미리 생성·관리된다"는 lifecycle 선언일 뿐, 트래픽 격리(network isolation)를 보장하지 않는다. 실제 격리는 blog_container가 외부 포트를 노출하지 않고 blog_network에만 연결되어 있다는 구성에서 비롯된다.
+
+## ✅ 적용 결과
+
+| 파일 | 변경 |
+|------|------|
+| `.env.example` | 서브넷 CIDR 예시 + external:true 의미 명시 |
+| `cloudflared/docker-compose.yml` | 사전 준비 6번: 네트워크 생성 절차 추가 |
+| `docker-compose.yml` | cloudflared 주석 참조 한 줄 추가 |
+| `package.json` | 1.1.0 → 1.1.2 |

--- a/docs/server/progress.index.md
+++ b/docs/server/progress.index.md
@@ -6,6 +6,7 @@
 
 | 날짜       | 주요 작업                              | 상태 |
 | ---------- | -------------------------------------- | ---- |
+| 2026-04-24 | Issue #108 cloudflared trusted proxy 서브넷 고정: `TRUSTED_PROXY_RANGES`를 단일 IP 대신 blog_network 서브넷 CIDR로 지정하도록 `.env.example` 및 compose 주석 가이드 추가, `package.json` 1.1.2 bump, v1.1.2 태그, PR #109 머지 | ✅   |
 | 2026-04-18 | Issue #98 Server PR/push CI 추가: `ci.yml` 신규 구성, Node 20 + pnpm 고정, MySQL service + `.env.test` 생성, PR 중복 실행 방지를 위해 `push`를 `main`으로 제한, PR #99 머지 | ✅   |
 | 2026-04-18 | Issue #96 Server API `/api` prefix 제거: route prefix/OAuth callback/Swagger 설명/통합 테스트를 루트 경로로 전환, `/health` lightweight probe 유지 + 상세 상태는 `/health/status`로 분리, `api-spec.md` 갱신, PR #97 머지 | ✅   |
 | 2026-04-10 | Issue #87 API spec/test alignment baseline: auth/guestbook/settings 계약 기준 테스트 정렬, 실제 앱 CSRF e2e 검증 추가, health/stats/settings-service 불안정성 수정, 전체 스위트 `17` files / `258` tests green 복구, PR #90 머지 | ✅   |

--- a/docs/server/progress.index.md
+++ b/docs/server/progress.index.md
@@ -6,6 +6,7 @@
 
 | 날짜       | 주요 작업                              | 상태 |
 | ---------- | -------------------------------------- | ---- |
+| 2026-04-24 | Issue #111 카테고리/태그 slug 생성 복구: Unicode slug 생성, category manual override, legacy repair script, review warning 3회 반영 후 PR #112 머지 | ✅   |
 | 2026-04-24 | Issue #108 cloudflared trusted proxy 서브넷 고정: `TRUSTED_PROXY_RANGES`를 단일 IP 대신 blog_network 서브넷 CIDR로 지정하도록 `.env.example` 및 compose 주석 가이드 추가, `package.json` 1.1.2 bump, v1.1.2 태그, PR #109 머지 | ✅   |
 | 2026-04-18 | Issue #98 Server PR/push CI 추가: `ci.yml` 신규 구성, Node 20 + pnpm 고정, MySQL service + `.env.test` 생성, PR 중복 실행 방지를 위해 `push`를 `main`으로 제한, PR #99 머지 | ✅   |
 | 2026-04-18 | Issue #96 Server API `/api` prefix 제거: route prefix/OAuth callback/Swagger 설명/통합 테스트를 루트 경로로 전환, `/health` lightweight probe 유지 + 상세 상태는 `/health/status`로 분리, `api-spec.md` 갱신, PR #97 머지 | ✅   |
@@ -65,6 +66,7 @@
 
 ## 🔗 상세 문서
 
+- [progress.2026-04-24.md](./progress/progress.2026-04-24.md) - Issue #111 taxonomy Unicode slug 복구 + category manual override + repair script + PR #112 머지
 - [progress.2026-04-18.md](./progress/progress.2026-04-18.md) - Issue #98 Server PR/push CI 추가 + PR #99 머지
 - [progress.2026-04-18.md](./progress/progress.2026-04-18.md) - Issue #96 server API `/api` prefix 제거 + health probe 계약 유지 + PR #97 머지
 - [progress.2026-04-10.md](./progress/progress.2026-04-10.md) - Issue #87 API spec/test alignment baseline + PR #90 머지

--- a/docs/server/progress.index.md
+++ b/docs/server/progress.index.md
@@ -6,6 +6,7 @@
 
 | 날짜       | 주요 작업                              | 상태 |
 | ---------- | -------------------------------------- | ---- |
+| 2026-04-25 | Issue #113 휴지통 `categoryId=NULL` 게시글 enrichment 500 복구: 관리자 목록/상세 null-tolerant enrichment, restore 400 guard, posts 회귀 테스트 추가, PR #114 머지 | ✅   |
 | 2026-04-24 | Issue #111 카테고리/태그 slug 생성 복구: Unicode slug 생성, category manual override, legacy repair script, review warning 3회 반영 후 PR #112 머지 | ✅   |
 | 2026-04-24 | Issue #108 cloudflared trusted proxy 서브넷 고정: `TRUSTED_PROXY_RANGES`를 단일 IP 대신 blog_network 서브넷 CIDR로 지정하도록 `.env.example` 및 compose 주석 가이드 추가, `package.json` 1.1.2 bump, v1.1.2 태그, PR #109 머지 | ✅   |
 | 2026-04-18 | Issue #98 Server PR/push CI 추가: `ci.yml` 신규 구성, Node 20 + pnpm 고정, MySQL service + `.env.test` 생성, PR 중복 실행 방지를 위해 `push`를 `main`으로 제한, PR #99 머지 | ✅   |
@@ -66,6 +67,7 @@
 
 ## 🔗 상세 문서
 
+- [progress.2026-04-25.md](./progress/progress.2026-04-25.md) - Issue #113 휴지통 `categoryId=NULL` 게시글 enrichment 500 복구 + PR #114 머지
 - [progress.2026-04-24.md](./progress/progress.2026-04-24.md) - Issue #111 taxonomy Unicode slug 복구 + category manual override + repair script + PR #112 머지
 - [progress.2026-04-18.md](./progress/progress.2026-04-18.md) - Issue #98 Server PR/push CI 추가 + PR #99 머지
 - [progress.2026-04-18.md](./progress/progress.2026-04-18.md) - Issue #96 server API `/api` prefix 제거 + health probe 계약 유지 + PR #97 머지

--- a/docs/server/progress.index.md
+++ b/docs/server/progress.index.md
@@ -6,6 +6,7 @@
 
 | 날짜       | 주요 작업                              | 상태 |
 | ---------- | -------------------------------------- | ---- |
+| 2026-04-25 | Issue #117 guestbook guest email optional 계약 반영: guest create schema/route test 반영 후 Codex review suggestion으로 OpenAPI 설명 문구 정렬, PR #118 머지 | ✅   |
 | 2026-04-25 | Issue #113 휴지통 `categoryId=NULL` 게시글 enrichment 500 복구: 관리자 목록/상세 null-tolerant enrichment, restore 400 guard, posts 회귀 테스트 추가, PR #114 머지 | ✅   |
 | 2026-04-24 | Issue #111 카테고리/태그 slug 생성 복구: Unicode slug 생성, category manual override, legacy repair script, review warning 3회 반영 후 PR #112 머지 | ✅   |
 | 2026-04-24 | Issue #108 cloudflared trusted proxy 서브넷 고정: `TRUSTED_PROXY_RANGES`를 단일 IP 대신 blog_network 서브넷 CIDR로 지정하도록 `.env.example` 및 compose 주석 가이드 추가, `package.json` 1.1.2 bump, v1.1.2 태그, PR #109 머지 | ✅   |
@@ -67,6 +68,7 @@
 
 ## 🔗 상세 문서
 
+- [progress.2026-04-25.md](./progress/progress.2026-04-25.md) - Issue #117 guestbook guest email optional 계약 반영 + PR #118 머지
 - [progress.2026-04-25.md](./progress/progress.2026-04-25.md) - Issue #113 휴지통 `categoryId=NULL` 게시글 enrichment 500 복구 + PR #114 머지
 - [progress.2026-04-24.md](./progress/progress.2026-04-24.md) - Issue #111 taxonomy Unicode slug 복구 + category manual override + repair script + PR #112 머지
 - [progress.2026-04-18.md](./progress/progress.2026-04-18.md) - Issue #98 Server PR/push CI 추가 + PR #99 머지

--- a/docs/server/progress.index.md
+++ b/docs/server/progress.index.md
@@ -6,6 +6,7 @@
 
 | 날짜       | 주요 작업                              | 상태 |
 | ---------- | -------------------------------------- | ---- |
+| 2026-04-29 | Issue #119 카테고리 일괄 삭제 API: `DELETE /categories/bulk` 추가, 단일 트랜잭션 기반 move/trash 처리와 검증/회귀 테스트 보강, PR #120 머지 | ✅   |
 | 2026-04-25 | Issue #117 guestbook guest email optional 계약 반영: guest create schema/route test 반영 후 Codex review suggestion으로 OpenAPI 설명 문구 정렬, PR #118 머지 | ✅   |
 | 2026-04-25 | Issue #113 휴지통 `categoryId=NULL` 게시글 enrichment 500 복구: 관리자 목록/상세 null-tolerant enrichment, restore 400 guard, posts 회귀 테스트 추가, PR #114 머지 | ✅   |
 | 2026-04-24 | Issue #111 카테고리/태그 slug 생성 복구: Unicode slug 생성, category manual override, legacy repair script, review warning 3회 반영 후 PR #112 머지 | ✅   |
@@ -68,6 +69,7 @@
 
 ## 🔗 상세 문서
 
+- [progress.2026-04-29.md](./progress/progress.2026-04-29.md) - Issue #119 카테고리 일괄 삭제 API + PR #120 머지
 - [progress.2026-04-25.md](./progress/progress.2026-04-25.md) - Issue #117 guestbook guest email optional 계약 반영 + PR #118 머지
 - [progress.2026-04-25.md](./progress/progress.2026-04-25.md) - Issue #113 휴지통 `categoryId=NULL` 게시글 enrichment 500 복구 + PR #114 머지
 - [progress.2026-04-24.md](./progress/progress.2026-04-24.md) - Issue #111 taxonomy Unicode slug 복구 + category manual override + repair script + PR #112 머지

--- a/docs/server/progress/progress.2026-04-24.md
+++ b/docs/server/progress/progress.2026-04-24.md
@@ -1,0 +1,35 @@
+# Server Progress - 2026-04-24
+
+## Issue #108 — cloudflared trusted proxy 서브넷 고정 (PR #109 머지, v1.1.2)
+
+**Status**: Merged
+
+### What was done
+
+배포 환경에서 관리자 로그인이 안되는 버그 재발을 방지했다. cloudflared 컨테이너 IP 변동에 강건하도록 `TRUSTED_PROXY_RANGES` 설정 가이드를 단일 IP에서 서브넷 CIDR 기반으로 전환했다.
+
+**파일 변경:**
+- `.env.example`: Docker Compose 배포 환경용 `TRUSTED_PROXY_RANGES` 서브넷 CIDR 예시(`172.28.0.0/24`)와 주석 가이드 추가. `external: true`의 lifecycle 의미와 실제 격리 근거를 분리 명시.
+- `cloudflared/docker-compose.yml`: 사전 준비 6번으로 `blog_network` 고정 서브넷 생성 명령과 확인·재생성 절차 추가.
+- `docker-compose.yml`: `blog_network` 생성 절차 참조 주석 한 줄 추가.
+- `package.json`: `version` 1.1.0 → 1.1.2 (tag v1.1.1과 파일 불일치 동시 정정).
+
+**운영 호스트 수동 작업 (배포 절차):**
+1. `docker network rm blog_network` (컨테이너 stop 후)
+2. `docker network create --driver bridge --subnet 172.28.0.0/24 blog_network`
+3. `.env`에 `TRUSTED_PROXY_RANGES=172.28.0.0/24` 설정
+4. cloudflared → blog_container 순서로 기동
+5. 로그인 응답 `Set-Cookie`에 `Secure; Domain=.pyosh.com` 포함 확인
+
+### Findings
+
+- Findings 017 참고: Docker `external: true` 네트워크는 서브넷 고정 없이 생성하면 IP 대역이 재생성 시 변경됨 → `TRUSTED_PROXY_RANGES`는 단일 IP 대신 서브넷 CIDR로 지정해야 함.
+
+### Review
+
+- 1라운드 `[SUGGESTION] 1`: `external: true`를 "내부 전용"으로 표현해 트래픽 격리를 보장하는 것처럼 읽힐 수 있다는 지적 → 주석에 external:true의 실제 의미(lifecycle 선언) 명시로 수정 후 skip-review 머지.
+
+### Verification
+
+- PR #109 squash merge → `main`
+- `git tag v1.1.2` → `origin` push 완료

--- a/docs/server/progress/progress.2026-04-24.md
+++ b/docs/server/progress/progress.2026-04-24.md
@@ -1,5 +1,33 @@
 # Server Progress - 2026-04-24
 
+## Issue #111 — 카테고리/태그 유니코드 slug 복구 및 관리자 category slug override (PR #112 머지)
+
+**Status**: Merged
+
+### What was done
+
+한글·이모지 등 비-ASCII 이름으로 category/tag를 만들 때 빈 slug 또는 `-2` 형태 legacy slug가 생성되던 서버 버그를 복구했다. category 생성/수정은 유니코드 slug를 기본으로 사용하고, 빈 결과만 `id` fallback으로 처리하도록 정리했다. 또한 관리자 category API에 수동 slug override를 추가했다.
+
+**파일 변경:**
+- `src/shared/slug.ts`: `needsLegacySlugRepair()` 추가로 post/category/tag가 동일한 legacy slug 판정 규칙을 공유.
+- `src/routes/categories/category.*`: create/update를 Unicode slug + retryable finalization 흐름으로 전환, 자동 충돌은 readable suffix(`slug-2`) 유지, manual override 충돌은 `400`으로 제어.
+- `src/routes/tags/tag.service.ts`: tag 생성/legacy repair를 Unicode slug 기반으로 전환하고, 같은 요청 내 slug 충돌을 순차 생성으로 직렬화.
+- `scripts/repair-taxonomy-slugs.ts`: dry-run 기본, `--apply`, `--target=categories|tags|all` 지원하는 one-off 복구 스크립트 추가.
+- `test/routes/categories.test.ts`, `test/routes/tags.test.ts`, `test/shared/slug.test.ts`: 한글 slug, 빈 결과 `id` fallback, readable suffix 유지, legacy repair, colliding tag 생성 회귀 테스트 추가.
+
+### Review
+
+- 리뷰 1차: category 자동 충돌이 숫자 slug로 퇴행하고 repair 스크립트가 부분 적용될 수 있다는 warning → readable suffix 복원, in-memory reservation + single transaction apply로 수정.
+- 리뷰 2차: category/tag 최종 slug update가 concurrent duplicate에서 raw DB error로 실패할 수 있다는 warning → duplicate-entry retry finalize 로직 추가.
+- 리뷰 3차: 같은 요청 내 신규 tag 생성이 병렬 실행되어 colliding normalized slug에서 stale snapshot 문제를 일으킬 수 있다는 warning → `newNames` 생성 경로를 순차화하고 회귀 테스트 추가.
+- 리뷰 4차: `0 critical / 0 warning / 0 suggestion` clean.
+
+### Verification
+
+- `pnpm compile:types`
+- `pnpm test` → `19` files, `282` tests passed
+- PR #112 squash merge → `main`
+
 ## Issue #108 — cloudflared trusted proxy 서브넷 고정 (PR #109 머지, v1.1.2)
 
 **Status**: Merged

--- a/docs/server/progress/progress.2026-04-25.md
+++ b/docs/server/progress/progress.2026-04-25.md
@@ -1,0 +1,23 @@
+# Server Progress - 2026-04-25
+
+## Issue #113 — 휴지통 categoryId NULL 게시글 enrichment 500 복구 (PR #114 머지)
+
+**Status**: Merged
+
+### What was done
+
+카테고리 삭제 시 `action=trash`로 이동된 게시글은 `categoryId`가 `NULL`이 되는데, posts 서비스가 이를 항상 존재하는 카테고리로 가정해 관리자 휴지통 목록과 상세 조회에서 `500`을 내던 버그를 복구했다. 이제 삭제된 uncategorized 게시글은 `categoryId: null`, `category: null`로 정상 응답하며, 카테고리가 없는 글은 단건/벌크 restore에서 `400`으로 명시적으로 차단된다.
+
+**파일 변경:**
+- `src/routes/posts/post.service.ts`: 목록/상세 enrichment를 `categoryId === null`에 안전하게 처리하고, 빈 category lookup을 건너뛰며, 단건/벌크 restore에 uncategorized guard 추가.
+- `src/routes/posts/post.schema.ts`: post 응답 스키마의 `categoryId`, `category`를 nullable로 조정.
+- `test/routes/posts.test.ts`: category `trash` 후 관리자 목록/상세 조회 회귀 테스트와 단건/벌크 restore `400` 검증 추가.
+
+### Review
+
+- codex review 결과 `0 critical / 0 warning / 0 suggestion` clean.
+
+### Verification
+
+- `pnpm test` → `19` files, `286` tests passed
+- PR #114 squash merge → `main`

--- a/docs/server/progress/progress.2026-04-25.md
+++ b/docs/server/progress/progress.2026-04-25.md
@@ -1,5 +1,29 @@
 # Server Progress - 2026-04-25
 
+## Issue #117 — Guestbook guest email optional 계약 반영 (PR #118 머지)
+
+**Status**: Merged
+
+### What was done
+
+게스트 방명록 생성 요청에서 `guestEmail`을 선택값으로 허용하는 변경이 PR #118로 올라간 상태에서 review 단계부터 파이프라인을 재개했다. Codex review는 동작/테스트 측면에서는 clean이었고, OpenAPI route description이 여전히 게스트가 이름, 이메일, 비밀번호를 모두 보내야 한다고 설명하는 문서 불일치 1건만 제안했다.
+
+제안은 유효하다고 판단해 `src/routes/guestbook/guestbook.route.ts`의 `POST /guestbook` 설명 문자열을 스키마와 일치하도록 수정했다. 이제 게스트는 이름과 비밀번호를 전달해야 하고, 이메일은 선택이라고 명시된다. suggestion-only 리뷰였기 때문에 재리뷰 없이 바로 finalize/merge 경로로 진행했다.
+
+**파일 변경:**
+- `src/routes/guestbook/guestbook.route.ts`: guestbook POST OpenAPI 설명을 `guestEmail` 선택 계약에 맞게 수정.
+
+### Review
+
+- codex review 결과 `0 critical / 0 warning / 1 suggestion`.
+- 반영 내용: OpenAPI 설명 문구가 optional email 계약과 어긋나던 부분 수정.
+
+### Verification
+
+- `pnpm test` 시도
+- 결과: worktree에 `node_modules`가 없어 `vitest: not found`로 실행 불가
+- PR #118 squash merge → `main`
+
 ## Issue #113 — 휴지통 categoryId NULL 게시글 enrichment 500 복구 (PR #114 머지)
 
 **Status**: Merged

--- a/docs/server/progress/progress.2026-04-29.md
+++ b/docs/server/progress/progress.2026-04-29.md
@@ -1,0 +1,29 @@
+# Server Progress - 2026-04-29
+
+## Issue #119 - 카테고리 일괄 삭제 API (PR #120 머지)
+
+**Status**: Merged
+
+### What was done
+
+관리자 카테고리 화면의 일괄 선택 삭제를 지원하기 위해 `DELETE /categories/bulk` API를 추가했다. 요청 본문은 `{ ids, action, moveTo }` 형태이며, 기존 단건 삭제의 `move`/`trash` 정책을 유지하면서 여러 카테고리를 단일 트랜잭션으로 처리한다.
+
+입력 검증은 빈 `ids`, 100개 초과, 중복 ID, `moveTo` 누락을 400으로 막도록 스키마와 서비스 양쪽에 방어를 두었다. 서비스 레이어에서는 선택된 카테고리 전체 존재 여부를 확인하고, 하위 카테고리가 있는 대상은 409로 거부하며, `moveTo`가 삭제 대상에 포함되거나 존재하지 않는 경우를 차단한다. `trash`는 미삭제 게시글을 soft delete하고 `categoryId`를 null로 정리하며, `move`는 미삭제 게시글만 대상 카테고리로 이동하고 이미 soft-deleted 된 게시글은 `categoryId`를 null로 정리한다.
+
+**파일 변경:**
+- `src/routes/categories/category.schema.ts`: 벌크 삭제 요청 스키마 추가.
+- `src/routes/categories/category.route.ts`: `DELETE /categories/bulk`를 `/:id`보다 앞에 등록하고 Admin 인증/CSRF 보호 적용.
+- `src/routes/categories/category.service.ts`: 트랜잭션 기반 `deleteCategories` 구현.
+- `test/routes/categories.test.ts`: 인증/CSRF route hook, 검증 실패, 하위 카테고리 실패, move/trash 성공 DB 상태, `/bulk` 정적 경로 매칭 회귀 테스트 추가.
+
+### Review
+
+- codex review 결과 `0 critical / 0 warning / 0 suggestion` clean.
+
+### Verification
+
+- `pnpm compile:types`
+- `pnpm lint`
+- `pnpm test test/routes/categories.test.ts` -> `42` tests passed
+- `pnpm test` -> `19` files, `298` tests passed
+- PR #120 squash merge -> `main`

--- a/docs/workspace/progress.index.md
+++ b/docs/workspace/progress.index.md
@@ -6,6 +6,7 @@
 
 | 날짜       | 주요 작업                            | 상태 |
 | ---------- | ------------------------------------ | ---- |
+| 2026-04-29 | 루트 워크스페이스 정리 - tracker/orchestrator 계열 도구 삭제, docs 기록은 `/dev-log` + git 히스토리로 유지 | done |
 | 2026-03-23 | 와이어프레임 color-mix()→rgba() 전면교체(99곳), inline-block 수정, Figma 직접 패치(Navigation×19, Highlighted Text×11, Code×26) | done |
 | 2026-03-23 | 와이어프레임 HTML 컬러 토큰/타이포그래피 컴플라이언스 수정 + Figma 캡처 (19개 프레임, node-id 70:2-88:2) | done |
 | 2026-03-14 | Codex schema contract fix + dev-codex-pipeline --tool override (PR #203) - review_schema.json required array, nullable path/line, review_publish.py null guard, SKILL.md parse-first TOOL pattern, 54 tests passing | done |

--- a/docs/workspace/progress/progress.2026-04-29.md
+++ b/docs/workspace/progress/progress.2026-04-29.md
@@ -1,0 +1,18 @@
+# Progress 2026-04-29
+
+## Root workspace cleanup - remove tracker/orchestrator tooling, preserve docs log
+
+Removed deprecated root-repo skills and Figma MCP setup first, then removed the remaining runtime tooling for the old orchestration stack: `tools/agent-tracker/` and `tools/orchctl/`.
+
+### Changes
+
+- Deleted root skills: `brainstorming`, `frontend-design`, `subagent-creator`, `writing-plans`, `dev-orchestrator`
+- Deleted Figma MCP setup and docs: `.mcp.json`, `mcp/figma-console/`, `mcp/figma-remote/`
+- Deleted runtime tooling: `tools/agent-tracker/`, `tools/orchctl/`
+- Updated `tools/docker/Dockerfile` to remove the build-time `tools/agent-tracker/setup.sh` dependency so Docker image builds do not fail after deletion
+
+### Notes
+
+- Historical records under `docs/` were intentionally preserved; future lookup should rely on git history and `/dev-log`
+- Active documentation still needs a follow-up pass for references to removed tracker/orchestrator tooling (for example `README.md`, `tools/ARCHITECTURE.md`)
+- This cleanup was not tied to a GitHub Issue


### PR DESCRIPTION
## Summary
- Archive 30 accumulated commits from `docs` into `main`.
- Add client, server, and workspace progress records for category workflows, taxonomy repair, public sidebar work, deploy notes, and the trusted proxy subnet finding.
- Carry forward workspace support updates, including agent tracking/orchestration tooling, skill docs, MCP/Figma notes, README/config refreshes, and related tool documentation.

## Verification
- Archive PR only; no client/server verification commands were run.