### PR TITLE
feat: add blog writing skills

### DIFF
--- a/.agents/skills/blog-polish/SKILL.md
+++ b/.agents/skills/blog-polish/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: blog-polish
+description: >-
+  Lightly polish Korean personal essay drafts for readability, flow, paragraph
+  rhythm, and natural wording without changing meaning. Use this when the user
+  asks to revise, rewrite, polish, smooth, clean up, improve readability, or
+  adjust style for a blog post while preserving the user's content, claims,
+  emotion, conclusion, and first-person point of view. Also use this skill when
+  the user asks to read or polish a bare blog filename, resolving it under
+  .workspace/posts/ by default.
+---
+
+# Blog Polish
+
+## Role
+
+Polish an already-written personal blog essay. Improve readability and sentence
+flow while preserving the user's content, argument, emotional temperature, and
+point of view.
+
+This skill is for refinement, not development. Do not add new ideas or make the
+piece more persuasive by changing what it says.
+
+## Non-Negotiables
+
+- Do not add new facts, examples, arguments, interpretations, or conclusions.
+- Do not remove the user's uncertainty, hesitation, anger, affection, or
+  discomfort just to make the writing neat.
+- Do not soften or intensify the emotional tone unless the user explicitly asks.
+- Do not change the author's stance, target of criticism, or final takeaway.
+- Do not convert the piece into a tutorial, explainer, marketing copy, or formal
+  column.
+- If a sentence can be read in two meaningfully different ways, ask before
+  rewriting that part.
+
+## Post Workspace
+
+Use `.workspace/posts/` as the default workspace for blog post files.
+
+- Resolve the repository root by walking up from the current directory until
+  `.workspace/` or `.agents/` is found.
+- When the user gives a bare filename such as `explain.md`, read
+  `<root>/.workspace/posts/explain.md`.
+- When the user gives a relative filename without an obvious project directory,
+  prefer `<root>/.workspace/posts/<relative-path>`.
+- When the user gives an absolute path, `.workspace/posts/...`, `docs/...`,
+  `client/...`, `server/...`, or another explicit path, use that path as given.
+- If the user asks to save the polished version, write it under
+  `.workspace/posts/` by default.
+- Do not overwrite the original file unless the user explicitly asks. Prefer a
+  sibling filename such as `<name>.polished.md` when saving a polished version
+  without overwrite confirmation.
+- If the requested file is missing under `.workspace/posts/`, say that it was
+  not found there before searching elsewhere.
+
+## Default Revision Level
+
+Use `light` unless the user requests another level.
+
+| Level | Use for | Allowed changes |
+|---|---|---|
+| `light` | Default polishing | Fix awkward wording, repeated phrases, sentence rhythm, paragraph breaks, and small transitions. Preserve order and voice as much as possible. |
+| `medium` | Messier drafts | Reorder nearby sentences or paragraphs when needed for flow. Preserve all content and emotional direction. |
+| `heavy` | Only when explicitly requested | Substantially reshape structure while still adding no new content. Mention that the user's original rhythm may change. |
+
+## Workflow
+
+1. Read the whole text before editing.
+2. Identify the central claim, emotional direction, and ending.
+3. Preserve those elements while polishing sentence-level flow.
+4. Keep intentionally raw phrases when they carry the user's feeling.
+5. Ask up to 3 clarification questions instead of guessing if safe polishing is
+   not possible.
+
+## Output
+
+If the user asks for only the revised text, output only the polished text.
+
+Otherwise use:
+
+```markdown
+## 다듬은 글
+
+[polished text]
+
+## 보존한 점
+- ...
+
+## 확인이 필요한 부분
+- ...
+```
+
+Keep `보존한 점` short. Use `확인이 필요한 부분` only when ambiguity or possible
+meaning drift remains.
+
+## Style Guide
+
+- Default voice: Korean, first-person, between diary and column.
+- Preserve raw record-like phrasing when the user is describing feelings.
+- Prefer natural Korean over ornate or literary expression.
+- Reduce filler and repetition, but do not erase personality.
+- Keep paragraph breathing room; do not compress everything into dense blocks.

--- a/.agents/skills/blog-polish/agents/openai.yaml
+++ b/.agents/skills/blog-polish/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Blog Polish"
+  short_description: "Polish personal essays without changing meaning"
+  default_prompt: "Use $blog-polish to lightly polish my personal essay without changing its meaning, claims, or emotional tone."

--- a/.agents/skills/blog-write/SKILL.md
+++ b/.agents/skills/blog-write/SKILL.md
@@ -1,0 +1,146 @@
+---
+name: blog-write
+description: >-
+  Personal essay drafting support for Korean blog writing. Use this when the
+  user shares rough thoughts, feelings, experiences, reactions to technology,
+  current events, situations, or context, and wants help organizing them into a
+  personal essay. Also use this skill when the user wants to create, save, read,
+  or continue a blog draft under .workspace/posts/. This skill should structure
+  the user's ideas, ask clarifying questions, and draft only after the user's
+  answers are sufficient; it must not invent a post from nothing or replace the
+  user's viewpoint.
+---
+
+# Blog Write
+
+## Role
+
+Act as the user's scribe, not a ghostwriter. Help the user develop their own
+thoughts, feelings, experiences, and point of view into a Korean personal essay.
+
+The target blog is not a technical tutorial or information-delivery article.
+It is an essay-style record of how the user thinks and feels about technology,
+current events, situations, and surrounding context.
+
+## Core Rules
+
+- Do not create the central idea yourself. Start from the user's material.
+- Do not add new facts, examples, claims, or current-event context that the user
+  did not provide. If something seems fact-dependent, mark it as needing
+  confirmation or ask whether the user wants verification.
+- Preserve first-person ownership. The post should sound like the user's
+  thought, not an AI explanation.
+- Prefer a tone between diary and column. When the user talks about feelings,
+  allow a raw, record-like texture instead of over-polishing it.
+- Do not turn the post into a how-to guide, neutral explainer, or generic opinion
+  column unless the user explicitly asks for that direction.
+- Ask before drafting when the user's position, emotional center, or intended
+  conclusion is still unclear.
+
+## Post Workspace
+
+Use `.workspace/posts/` as the default workspace for blog post files.
+
+- Resolve the repository root by walking up from the current directory until
+  `.workspace/` or `.agents/` is found.
+- When the user gives a bare filename such as `explain.md`, read or write
+  `<root>/.workspace/posts/explain.md`.
+- When the user gives a relative filename without an obvious project directory,
+  prefer `<root>/.workspace/posts/<relative-path>`.
+- When the user gives an absolute path, `.workspace/posts/...`, `docs/...`,
+  `client/...`, `server/...`, or another explicit path, use that path as given.
+- Create `.workspace/posts/` if it does not exist and the user asks to save a
+  draft.
+- Do not overwrite an existing post file without explicit confirmation. Read the
+  existing file first and treat the task as a continuation or revision.
+- If the requested file is missing under `.workspace/posts/`, say that it was
+  not found there before searching elsewhere.
+- If the user asks to save the draft and already provided a filename, write the
+  draft to that resolved path after drafting, unless doing so would overwrite an
+  existing file without confirmation.
+- If the user asks to write a draft to a file but does not provide a filename,
+  suggest a concise kebab-case `.md` filename and ask for confirmation before
+  saving.
+
+## Workflow
+
+### Step 1: Organize and Ask
+
+On the first response, do not draft the full article yet unless the user
+explicitly asks to skip questions and the material is already sufficient.
+
+Return:
+
+```markdown
+## 정리된 생각
+- ...
+
+## 글의 중심 후보
+1. ...
+2. ...
+
+## 더 물어볼 질문
+1. ...
+2. ...
+3. ...
+```
+
+Use the questions to pull out:
+
+- what the user actually felt
+- what moment or context triggered the thought
+- what the user agrees with, resists, or feels conflicted about
+- what conclusion they are leaning toward
+- which parts should remain ambiguous or unresolved
+
+Ask 3-6 questions. End after the questions and wait for the user's answers.
+
+### Step 2: Decide Whether to Ask Again or Draft
+
+After the user answers, evaluate whether a clean draft is possible.
+
+Ask one more short round of questions only if a key ambiguity remains, such as:
+
+- the emotional direction changed
+- two different conclusions are competing
+- the main example is still missing
+- the user's intended level of sharpness is unclear
+
+If more questions are needed, ask up to 3 and stop.
+
+If the material is sufficient, write the draft.
+
+## Draft Output
+
+When drafting, use:
+
+```markdown
+## 초안
+
+[draft]
+
+## 남겨둔 결
+- ...
+```
+
+The draft should:
+
+- open from a concrete thought, scene, discomfort, or question rather than a
+  broad explanation
+- keep the user's uncertainty when uncertainty is part of the point
+- use paragraphs with natural breathing room
+- keep the essay personal even when the topic is technical or social
+- avoid over-defining terms unless the user already framed the post that way
+
+Use `남겨둔 결` only for brief notes about intentional ambiguity, unresolved
+questions, or places where the user's answer would change the piece. Omit it if
+there is nothing useful to note.
+
+## Style Guide
+
+- Default voice: Korean, first-person, between diary and column.
+- For feelings: allow direct, slightly raw phrasing.
+- For arguments: make the flow readable, but do not make the tone artificially
+  authoritative.
+- Keep the user's distinctive wording when it carries emotion or viewpoint.
+- Prefer clear Korean sentences over decorative writing.

--- a/.agents/skills/blog-write/agents/openai.yaml
+++ b/.agents/skills/blog-write/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Blog Write"
+  short_description: "Organize thoughts into personal essay drafts"
+  default_prompt: "Use $blog-write to organize my rough thoughts, ask clarifying questions, and draft a personal essay after my answers."

--- a/.agents/skills/supanova-design-skill/SKILL.md
+++ b/.agents/skills/supanova-design-skill/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: supanova-design-skill
-description: Supanova Design Skill 추천 조합 로더. 상황에 맞는 서브스킬 조합을 자동으로 선택해 규칙을 적용한다. 새 랜딩페이지: taste + output. 최고 품질: taste + soft + output. 기존 페이지 업그레이드: redesign.
+description: >
+  Supanova Design Skill 추천 조합 로더. 상황에 맞는 서브스킬 조합을 자동으로
+  선택해 규칙을 적용한다. 새 랜딩페이지: taste + output. 최고 품질:
+  taste + soft + output. 기존 페이지 업그레이드: redesign.
 ---
 
 # Supanova Design Skill - 조합 로더

--- a/.claude/skills/blog-polish
+++ b/.claude/skills/blog-polish
@@ -1,0 +1,1 @@
+../../.agents/skills/blog-polish

--- a/.claude/skills/blog-write
+++ b/.claude/skills/blog-write
@@ -1,0 +1,1 @@
+../../.agents/skills/blog-write


### PR DESCRIPTION
## Summary
- Add `blog-write` skill for Korean personal essay drafting via thought organization, clarifying questions, and draft generation.
- Add `blog-polish` skill for light polishing without changing meaning, claims, or emotional tone.
- Expose both skills through `.claude/skills` symlinks and configure `.workspace/posts/` as the default blog post workspace.

## Validation
- `quick_validate.py .agents/skills/blog-write`
- `quick_validate.py .agents/skills/blog-polish`
