### PR TITLE
docs: asset category wireframes

### DIFF
--- a/docs/client/designs/admin/admin-asset.html
+++ b/docs/client/designs/admin/admin-asset.html
@@ -358,6 +358,41 @@
     .admin-tab:hover{color:var(--text2);}
     .admin-tab.active{background:rgba(138,111,224,0.10);color:var(--primary1);}
 
+    /* Category */
+    .category-chip{
+      display:inline-flex;align-items:center;gap:6px;
+      padding:7px 12px;border-radius:999px;font-size:13px;font-weight:500;
+      color:var(--text2);background:var(--background1);border:1px solid var(--border4);
+      cursor:pointer;transition:background .15s,border-color .15s,color .15s;
+    }
+    .category-chip:hover{background:var(--background3);border-color:var(--border3);}
+    .category-chip.active{background:rgba(138,111,224,0.12);border-color:rgba(138,111,224,0.35);color:var(--primary1);}
+    .category-count{font-family:'Outfit','Gothic A1',sans-serif;font-size:12px;color:var(--text4);}
+    .category-chip.active .category-count{color:var(--primary1);}
+    .category-dot{width:8px;height:8px;border-radius:50%;background:var(--grey3);flex-shrink:0;}
+    .category-dot.thumbnail{background:var(--primary1);}
+    .category-dot.default{background:var(--positive1);}
+    .category-dot.uncategorized{background:var(--grey3);}
+    .category-dot.custom{background:var(--yellow1);}
+    .asset-name{display:flex;flex-direction:column;gap:2px;min-width:0;}
+    .asset-display-name{font-size:14px;line-height:1.25rem;font-weight:600;color:var(--text1);}
+    .asset-file-name{font-size:12px;line-height:1rem;color:var(--text4);}
+    .asset-card-footer{display:flex;align-items:flex-start;justify-content:space-between;gap:8px;margin-top:8px;}
+    .asset-card-footer p{min-width:0;display:-webkit-box;-webkit-line-clamp:1;-webkit-box-orient:vertical;overflow:hidden;}
+    .category-mini{
+      display:inline-flex;align-items:center;gap:4px;
+      padding:3px 7px;border-radius:999px;font-size:11px;font-weight:600;
+      background:var(--background3);color:var(--text3);white-space:nowrap;
+    }
+    .category-mini.thumbnail{background:rgba(138,111,224,0.12);color:var(--primary1);}
+    .category-mini.default{background:rgba(7,133,86,0.10);color:var(--positive1);}
+    .category-mini.uncategorized{background:rgba(144,153,161,0.12);color:var(--grey4);}
+    .category-table-row{
+      display:grid;grid-template-columns:minmax(0,1fr) 72px 150px;gap:12px;align-items:center;
+      padding:10px 0;border-bottom:1px solid var(--border4);
+    }
+    .category-table-row:last-child{border-bottom:none;}
+
     /* ═══ Page-Specific Styles ═══ */
 
     /* Hover overlay: URL copy button only (top-right) */
@@ -379,12 +414,12 @@
       accent-color:var(--primary1);display:none;
     }
     .selection-mode .asset-card .select-checkbox{display:block;}
-    .asset-card.selected{outline:2px solid var(--primary1);outline-offset:-2px;border-radius:12px;}
+    .selection-mode .asset-card.selected{outline:2px solid var(--primary1);outline-offset:-2px;border-radius:12px;}
 
     /* Selection action bar */
     .selection-bar{
       position:sticky;top:56px;z-index:8;
-      display:none;align-items:center;gap:12px;
+      display:none;align-items:center;gap:12px;flex-wrap:wrap;
       padding:10px 16px;border-radius:10px;margin-bottom:16px;
       background:var(--background2);border:1px solid var(--border3);
       box-shadow:0 2px 8px rgba(0,0,0,.08);
@@ -406,6 +441,7 @@
 
     @media(max-width:639px){
       .dropzone{padding:24px 16px;}
+      .category-table-row{grid-template-columns:minmax(0,1fr);gap:8px;}
     }
     @media(max-width:767px){
       .modal-content.modal-asset-detail{
@@ -504,6 +540,20 @@
           <p class="text-body-sm font-medium" style="color:var(--text2);">이미지를 드래그하거나 클릭하여 업로드</p>
           <p class="text-ui-xs" style="color:var(--text4);">JPEG, PNG, GIF, WebP, SVG / 최대 10MB / 5개까지 동시 업로드</p>
         </div>
+        <div class="grid grid-cols-1 md:grid-cols-[180px_1fr] gap-3 w-full max-w-2xl mx-auto mt-5 text-left" onclick="event.stopPropagation()">
+          <label class="flex flex-col gap-1">
+            <span class="text-ui-xs font-medium" style="color:var(--text3);">업로드 카테고리</span>
+            <select class="admin-select w-full">
+              <option>기본</option>
+              <option>썸네일</option>
+              <option>미분류</option>
+            </select>
+          </label>
+          <label class="flex flex-col gap-1">
+            <span class="text-ui-xs font-medium" style="color:var(--text3);">별명</span>
+            <input class="admin-input" placeholder="비워두면 파일명을 사용" value="">
+          </label>
+        </div>
         <input type="file" id="fileInput" class="hidden" multiple accept="image/jpeg,image/png,image/gif,image/webp,image/svg+xml">
       </div>
 
@@ -524,22 +574,41 @@
           </div>
         </div>
         <!-- Queue items -->
-        <div class="flex flex-row gap-3 flex-wrap">
-          <!-- Completed item -->
-          <div class="flex items-center gap-3 px-3 py-2 rounded-lg" style="background:var(--background1);border:1px solid var(--border4);">
+        <div class="grid grid-cols-1 lg:grid-cols-2 gap-3">
+          <!-- Pending item with editable metadata -->
+          <div class="grid grid-cols-[64px_minmax(0,1fr)] gap-3 px-3 py-3 rounded-lg" style="background:var(--background1);border:1px solid var(--border4);">
             <img src="https://picsum.photos/seed/upload-done/64/48" alt="미리보기" class="w-16 h-12 rounded object-cover" style="min-width:64px;">
-            <div class="flex flex-col gap-0.5 min-w-0">
-              <span class="text-ui-sm font-medium line-clamp-1" style="color:var(--text1);">screenshot-01.png</span>
-              <span class="text-ui-xs" style="color:var(--text4);">2.4 MB</span>
+            <div class="flex flex-col gap-2 min-w-0">
+              <div class="flex items-center gap-2">
+                <span class="text-ui-sm font-medium line-clamp-1" style="color:var(--text1);">screenshot-01.png</span>
+                <span class="text-ui-xs shrink-0" style="color:var(--text4);">2.4 MB</span>
+              </div>
+              <div class="grid grid-cols-1 sm:grid-cols-[minmax(0,1fr)_128px] gap-2">
+                <input class="admin-input" style="padding-top:6px;padding-bottom:6px;font-size:13px;" value="설정 화면 캡처" aria-label="에셋 별명">
+                <select class="admin-select w-full" style="padding-top:6px;padding-bottom:6px;font-size:13px;" aria-label="에셋 카테고리">
+                  <option selected>기본</option>
+                  <option>썸네일</option>
+                  <option>미분류</option>
+                </select>
+              </div>
             </div>
-            <iconify-icon icon="solar:check-circle-bold" width="20" style="color:var(--positive1);flex-shrink:0;"></iconify-icon>
           </div>
-          <!-- In-progress item -->
-          <div class="flex items-center gap-3 px-3 py-2 rounded-lg" style="background:var(--background1);border:1px solid var(--border4);">
+          <!-- In-progress item with locked metadata -->
+          <div class="grid grid-cols-[64px_minmax(0,1fr)] gap-3 px-3 py-3 rounded-lg" style="background:var(--background1);border:1px solid var(--border4);">
             <div class="w-16 h-12 rounded flex-shrink-0" style="background:var(--background3);min-width:64px;"></div>
-            <div class="flex flex-col gap-1 min-w-0" style="min-width:120px;">
-              <span class="text-ui-sm font-medium line-clamp-1" style="color:var(--text1);">architecture-diagram.png</span>
-              <span class="text-ui-xs" style="color:var(--text4);">5.1 MB</span>
+            <div class="flex flex-col gap-2 min-w-0">
+              <div class="flex items-center gap-2">
+                <span class="text-ui-sm font-medium line-clamp-1" style="color:var(--text1);">architecture-diagram.png</span>
+                <span class="text-ui-xs shrink-0" style="color:var(--text4);">5.1 MB</span>
+              </div>
+              <div class="grid grid-cols-1 sm:grid-cols-[minmax(0,1fr)_128px] gap-2 opacity-70">
+                <input class="admin-input" style="padding-top:6px;padding-bottom:6px;font-size:13px;" value="아키텍처 다이어그램" disabled aria-label="에셋 별명">
+                <select class="admin-select w-full" style="padding-top:6px;padding-bottom:6px;font-size:13px;" disabled aria-label="에셋 카테고리">
+                  <option selected>기본</option>
+                  <option>썸네일</option>
+                  <option>미분류</option>
+                </select>
+              </div>
               <div class="w-full rounded-full" style="background:var(--background3);height:6px;">
                 <div class="rounded-full" style="width:60%;background:var(--primary1);height:6px;"></div>
               </div>
@@ -548,19 +617,65 @@
         </div>
       </div>
 
+      <!-- ═══ Category Filters ═══ -->
+      <div class="admin-card mb-4 reveal-stagger" style="padding:16px;">
+        <div class="flex flex-col gap-4">
+          <div class="flex flex-col lg:flex-row lg:items-center gap-3">
+            <div class="flex flex-wrap items-center gap-2">
+              <button class="category-chip active" type="button" onclick="setCategoryFilter(this)">
+                전체 <span class="category-count">42</span>
+              </button>
+              <button class="category-chip" type="button" onclick="setCategoryFilter(this)">
+                <span class="category-dot thumbnail"></span>썸네일 <span class="category-count">6</span>
+              </button>
+              <button class="category-chip" type="button" onclick="setCategoryFilter(this)">
+                <span class="category-dot default"></span>기본 <span class="category-count">28</span>
+              </button>
+              <button class="category-chip" type="button" onclick="setCategoryFilter(this)">
+                <span class="category-dot uncategorized"></span>미분류 <span class="category-count">8</span>
+              </button>
+            </div>
+            <button class="btn-secondary lg:ml-auto" style="padding:7px 12px;font-size:13px;" onclick="openModal('categoryModal')">
+              <iconify-icon icon="solar:folder-with-files-linear" width="16"></iconify-icon>
+              카테고리 관리
+            </button>
+          </div>
+          <div class="grid grid-cols-1 md:grid-cols-[minmax(0,1fr)_180px_120px] gap-2">
+            <label class="relative">
+              <iconify-icon icon="solar:magnifer-linear" width="16" style="position:absolute;left:12px;top:50%;transform:translateY(-50%);color:var(--text4);"></iconify-icon>
+              <input class="admin-input" style="padding-left:36px;" placeholder="별명 또는 파일명 검색" value="">
+            </label>
+            <select class="admin-select w-full">
+              <option>최근 업로드순</option>
+              <option>파일명순</option>
+              <option>용량순</option>
+            </select>
+            <button class="btn-secondary" style="padding:8px 12px;font-size:13px;" onclick="toggleSelectionMode()">
+              <iconify-icon icon="solar:check-square-linear" width="16"></iconify-icon>
+              선택
+            </button>
+          </div>
+        </div>
+      </div>
+
       <!-- ═══ Gallery Toolbar ═══ -->
       <div class="flex items-center justify-between mb-4 reveal-stagger">
         <p class="text-ui-sm" style="color:var(--text3);">총 42개</p>
-        <button class="btn-secondary" style="padding:6px 14px;font-size:13px;" onclick="toggleSelectionMode()">
-          <iconify-icon icon="solar:check-square-linear" width="16"></iconify-icon>
-          선택
-        </button>
+        <div class="flex items-center gap-2">
+          <span class="text-ui-xs hidden sm:inline" style="color:var(--text4);">카테고리는 정렬과 경로에 영향을 주지 않음</span>
+        </div>
       </div>
 
       <!-- ═══ Selection Mode Action Bar (sticky, shown only in selection mode) ═══ -->
       <div class="selection-bar" id="selectionBar">
         <span class="text-ui-sm font-medium" style="color:var(--primary1);">3개 선택됨</span>
-        <div class="flex items-center gap-2 ml-auto">
+        <div class="flex flex-wrap items-center gap-2 ml-auto">
+          <select class="admin-select" style="padding-top:6px;padding-bottom:6px;font-size:13px;">
+            <option>카테고리 변경</option>
+            <option>썸네일</option>
+            <option>기본</option>
+            <option>미분류</option>
+          </select>
           <button class="btn-secondary" style="padding:6px 12px;font-size:13px;" onclick="selectAll()">
             <iconify-icon icon="solar:checklist-linear" width="16"></iconify-icon>
             전체 선택
@@ -590,8 +705,14 @@
             </div>
           </div>
           <div class="p-3">
-            <p class="text-ui-sm font-medium line-clamp-1" style="color:var(--text1);">react-lifecycle-diagram.png</p>
-            <p class="text-ui-xs" style="color:var(--text4);">3.2 MB / 1920x1080 / 2026.03.15</p>
+            <div class="asset-name">
+              <p class="asset-display-name line-clamp-1">React 생명주기 대표 이미지</p>
+              <p class="asset-file-name line-clamp-1">react-lifecycle-diagram.png</p>
+            </div>
+            <div class="asset-card-footer">
+              <p class="text-ui-xs" style="color:var(--text4);">3.2 MB / 1920x1080 / 2026.03.15</p>
+              <span class="category-mini thumbnail">썸네일</span>
+            </div>
           </div>
         </div>
 
@@ -607,8 +728,14 @@
             </div>
           </div>
           <div class="p-3">
-            <p class="text-ui-sm font-medium line-clamp-1" style="color:var(--text1);">nextjs-routing-flow.png</p>
-            <p class="text-ui-xs" style="color:var(--text4);">2.1 MB / 1600x900 / 2026.03.12</p>
+            <div class="asset-name">
+              <p class="asset-display-name line-clamp-1">Next.js 라우팅 플로우</p>
+              <p class="asset-file-name line-clamp-1">nextjs-routing-flow.png</p>
+            </div>
+            <div class="asset-card-footer">
+              <p class="text-ui-xs" style="color:var(--text4);">2.1 MB / 1600x900 / 2026.03.12</p>
+              <span class="category-mini default">기본</span>
+            </div>
           </div>
         </div>
 
@@ -624,8 +751,14 @@
             </div>
           </div>
           <div class="p-3">
-            <p class="text-ui-sm font-medium line-clamp-1" style="color:var(--text1);">css-grid-cheatsheet.png</p>
-            <p class="text-ui-xs" style="color:var(--text4);">4.5 MB / 2400x1350 / 2026.03.10</p>
+            <div class="asset-name">
+              <p class="asset-display-name line-clamp-1">CSS Grid 요약표</p>
+              <p class="asset-file-name line-clamp-1">css-grid-cheatsheet.png</p>
+            </div>
+            <div class="asset-card-footer">
+              <p class="text-ui-xs" style="color:var(--text4);">4.5 MB / 2400x1350 / 2026.03.10</p>
+              <span class="category-mini default">기본</span>
+            </div>
           </div>
         </div>
 
@@ -641,8 +774,14 @@
             </div>
           </div>
           <div class="p-3">
-            <p class="text-ui-sm font-medium line-clamp-1" style="color:var(--text1);">docker-architecture.png</p>
-            <p class="text-ui-xs" style="color:var(--text4);">1.8 MB / 1280x720 / 2026.03.08</p>
+            <div class="asset-name">
+              <p class="asset-display-name line-clamp-1">도커 아키텍처 다이어그램</p>
+              <p class="asset-file-name line-clamp-1">docker-architecture.png</p>
+            </div>
+            <div class="asset-card-footer">
+              <p class="text-ui-xs" style="color:var(--text4);">1.8 MB / 1280x720 / 2026.03.08</p>
+              <span class="category-mini default">기본</span>
+            </div>
           </div>
         </div>
 
@@ -658,8 +797,14 @@
             </div>
           </div>
           <div class="p-3">
-            <p class="text-ui-sm font-medium line-clamp-1" style="color:var(--text1);">api-response-example.png</p>
-            <p class="text-ui-xs" style="color:var(--text4);">0.9 MB / 800x600 / 2026.03.06</p>
+            <div class="asset-name">
+              <p class="asset-display-name line-clamp-1">API 응답 예시</p>
+              <p class="asset-file-name line-clamp-1">api-response-example.png</p>
+            </div>
+            <div class="asset-card-footer">
+              <p class="text-ui-xs" style="color:var(--text4);">0.9 MB / 800x600 / 2026.03.06</p>
+              <span class="category-mini uncategorized">미분류</span>
+            </div>
           </div>
         </div>
 
@@ -675,8 +820,14 @@
             </div>
           </div>
           <div class="p-3">
-            <p class="text-ui-sm font-medium line-clamp-1" style="color:var(--text1);">typescript-type-hierarchy.png</p>
-            <p class="text-ui-xs" style="color:var(--text4);">2.7 MB / 1920x1080 / 2026.03.04</p>
+            <div class="asset-name">
+              <p class="asset-display-name line-clamp-1">타입스크립트 타입 계층</p>
+              <p class="asset-file-name line-clamp-1">typescript-type-hierarchy.png</p>
+            </div>
+            <div class="asset-card-footer">
+              <p class="text-ui-xs" style="color:var(--text4);">2.7 MB / 1920x1080 / 2026.03.04</p>
+              <span class="category-mini default">기본</span>
+            </div>
           </div>
         </div>
 
@@ -692,8 +843,14 @@
             </div>
           </div>
           <div class="p-3">
-            <p class="text-ui-sm font-medium line-clamp-1" style="color:var(--text1);">vitest-coverage-report.png</p>
-            <p class="text-ui-xs" style="color:var(--text4);">1.4 MB / 1440x900 / 2026.03.02</p>
+            <div class="asset-name">
+              <p class="asset-display-name line-clamp-1">Vitest 커버리지 리포트</p>
+              <p class="asset-file-name line-clamp-1">vitest-coverage-report.png</p>
+            </div>
+            <div class="asset-card-footer">
+              <p class="text-ui-xs" style="color:var(--text4);">1.4 MB / 1440x900 / 2026.03.02</p>
+              <span class="category-mini uncategorized">미분류</span>
+            </div>
           </div>
         </div>
 
@@ -709,8 +866,14 @@
             </div>
           </div>
           <div class="p-3">
-            <p class="text-ui-sm font-medium line-clamp-1" style="color:var(--text1);">github-actions-workflow.png</p>
-            <p class="text-ui-xs" style="color:var(--text4);">3.1 MB / 2000x1200 / 2026.02.28</p>
+            <div class="asset-name">
+              <p class="asset-display-name line-clamp-1">GitHub Actions 워크플로</p>
+              <p class="asset-file-name line-clamp-1">github-actions-workflow.png</p>
+            </div>
+            <div class="asset-card-footer">
+              <p class="text-ui-xs" style="color:var(--text4);">3.1 MB / 2000x1200 / 2026.02.28</p>
+              <span class="category-mini default">기본</span>
+            </div>
           </div>
         </div>
 
@@ -726,8 +889,14 @@
             </div>
           </div>
           <div class="p-3">
-            <p class="text-ui-sm font-medium line-clamp-1" style="color:var(--text1);">database-schema-v2.png</p>
-            <p class="text-ui-xs" style="color:var(--text4);">2.3 MB / 1600x1000 / 2026.02.25</p>
+            <div class="asset-name">
+              <p class="asset-display-name line-clamp-1">데이터베이스 스키마 v2</p>
+              <p class="asset-file-name line-clamp-1">database-schema-v2.png</p>
+            </div>
+            <div class="asset-card-footer">
+              <p class="text-ui-xs" style="color:var(--text4);">2.3 MB / 1600x1000 / 2026.02.25</p>
+              <span class="category-mini default">기본</span>
+            </div>
           </div>
         </div>
 
@@ -743,8 +912,14 @@
             </div>
           </div>
           <div class="p-3">
-            <p class="text-ui-sm font-medium line-clamp-1" style="color:var(--text1);">performance-metrics.png</p>
-            <p class="text-ui-xs" style="color:var(--text4);">1.6 MB / 1280x800 / 2026.02.22</p>
+            <div class="asset-name">
+              <p class="asset-display-name line-clamp-1">성능 지표 캡처</p>
+              <p class="asset-file-name line-clamp-1">performance-metrics.png</p>
+            </div>
+            <div class="asset-card-footer">
+              <p class="text-ui-xs" style="color:var(--text4);">1.6 MB / 1280x800 / 2026.02.22</p>
+              <span class="category-mini uncategorized">미분류</span>
+            </div>
           </div>
         </div>
 
@@ -760,8 +935,14 @@
             </div>
           </div>
           <div class="p-3">
-            <p class="text-ui-sm font-medium line-clamp-1" style="color:var(--text1);">blog-thumbnail-rsc.png</p>
-            <p class="text-ui-xs" style="color:var(--text4);">0.7 MB / 800x450 / 2026.02.20</p>
+            <div class="asset-name">
+              <p class="asset-display-name line-clamp-1">RSC 글 대표 썸네일</p>
+              <p class="asset-file-name line-clamp-1">blog-thumbnail-rsc.png</p>
+            </div>
+            <div class="asset-card-footer">
+              <p class="text-ui-xs" style="color:var(--text4);">0.7 MB / 800x450 / 2026.02.20</p>
+              <span class="category-mini thumbnail">썸네일</span>
+            </div>
           </div>
         </div>
 
@@ -777,8 +958,14 @@
             </div>
           </div>
           <div class="p-3">
-            <p class="text-ui-sm font-medium line-clamp-1" style="color:var(--text1);">zustand-store-pattern.png</p>
-            <p class="text-ui-xs" style="color:var(--text4);">1.9 MB / 1440x810 / 2026.02.18</p>
+            <div class="asset-name">
+              <p class="asset-display-name line-clamp-1">Zustand 스토어 패턴</p>
+              <p class="asset-file-name line-clamp-1">zustand-store-pattern.png</p>
+            </div>
+            <div class="asset-card-footer">
+              <p class="text-ui-xs" style="color:var(--text4);">1.9 MB / 1440x810 / 2026.02.18</p>
+              <span class="category-mini default">기본</span>
+            </div>
           </div>
         </div>
 
@@ -801,11 +988,14 @@
       </div>
 
       <!-- ═══ Asset Detail Modal ═══ -->
-      <div class="modal-overlay open" id="assetModal" onclick="if(event.target===this)closeModal('assetModal')">
-        <div class="modal-content modal-asset-detail max-w-2xl">
+      <div class="modal-overlay" id="assetModal" onclick="if(event.target===this)closeModal('assetModal')">
+        <div class="modal-content modal-asset-detail max-w-3xl">
           <!-- Header -->
           <div class="flex items-center justify-between mb-4">
-            <h3 class="text-lg font-bold" style="color:var(--text1);">react-lifecycle-diagram.png</h3>
+            <div class="min-w-0">
+              <h3 class="text-lg font-bold line-clamp-1" style="color:var(--text1);">React 생명주기 대표 이미지</h3>
+              <p class="text-ui-xs line-clamp-1" style="color:var(--text4);">react-lifecycle-diagram.png</p>
+            </div>
             <button class="btn-ghost" onclick="closeModal('assetModal')" aria-label="닫기">
               <iconify-icon icon="solar:close-circle-linear" width="22"></iconify-icon>
             </button>
@@ -819,6 +1009,21 @@
             <button class="modal-nav-btn next" onclick="navigateAsset(1)" aria-label="다음 에셋">
               <iconify-icon icon="solar:alt-arrow-right-linear" width="20"></iconify-icon>
             </button>
+          </div>
+          <!-- Editable Info -->
+          <div class="grid grid-cols-1 md:grid-cols-[minmax(0,1fr)_180px] gap-3 mb-4">
+            <label class="flex flex-col gap-1">
+              <span class="text-ui-xs font-medium" style="color:var(--text3);">별명</span>
+              <input class="admin-input" value="React 생명주기 대표 이미지">
+            </label>
+            <label class="flex flex-col gap-1">
+              <span class="text-ui-xs font-medium" style="color:var(--text3);">카테고리</span>
+              <select class="admin-select w-full">
+                <option selected>썸네일</option>
+                <option>기본</option>
+                <option>미분류</option>
+              </select>
+            </label>
           </div>
           <!-- Metadata -->
           <div class="grid grid-cols-2 gap-x-6 gap-y-3 mb-6">
@@ -843,12 +1048,24 @@
               <p class="text-ui-sm" style="color:var(--text1);">2026.03.15 14:32</p>
             </div>
             <div>
+              <p class="text-ui-xs" style="color:var(--text3);">카테고리</p>
+              <p class="text-ui-sm" style="color:var(--text1);">썸네일</p>
+            </div>
+            <div>
+              <p class="text-ui-xs" style="color:var(--text3);">업로드 위치</p>
+              <p class="text-ui-sm" style="color:var(--text1);">썸네일 선택</p>
+            </div>
+            <div>
               <p class="text-ui-xs" style="color:var(--text3);">URL</p>
               <p class="text-ui-sm line-clamp-1" style="color:var(--text1);">/uploads/2026/03/f7a3b2c1-xxxx.png</p>
             </div>
           </div>
           <!-- Action Buttons: URL copy, markdown copy, delete -->
           <div class="flex flex-wrap gap-2">
+            <button class="btn-primary">
+              <iconify-icon icon="solar:diskette-linear" width="16"></iconify-icon>
+              저장
+            </button>
             <button class="btn-secondary">
               <iconify-icon icon="solar:link-minimalistic-2-linear" width="16"></iconify-icon>
               URL 복사
@@ -863,6 +1080,86 @@
                 삭제
               </button>
             </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- ═══ Asset Category Modal ═══ -->
+      <div class="modal-overlay" id="categoryModal" onclick="if(event.target===this)closeModal('categoryModal')">
+        <div class="modal-content max-w-xl">
+          <div class="flex items-center justify-between mb-5">
+            <h3 class="text-lg font-bold" style="color:var(--text1);">에셋 카테고리</h3>
+            <button class="btn-ghost" onclick="closeModal('categoryModal')" aria-label="닫기">
+              <iconify-icon icon="solar:close-circle-linear" width="22"></iconify-icon>
+            </button>
+          </div>
+          <div class="flex flex-col sm:flex-row gap-2 mb-5">
+            <input class="admin-input" placeholder="새 카테고리 이름" value="">
+            <button class="btn-primary shrink-0">
+              <iconify-icon icon="solar:add-circle-linear" width="16"></iconify-icon>
+              생성
+            </button>
+          </div>
+          <div class="rounded-xl px-4" style="background:var(--background2);border:1px solid var(--border4);">
+            <div class="category-table-row">
+              <div class="flex items-center gap-2 min-w-0">
+                <span class="category-dot thumbnail"></span>
+                <div class="min-w-0">
+                  <p class="text-ui-sm font-semibold line-clamp-1" style="color:var(--text1);">썸네일</p>
+                  <p class="text-ui-xs" style="color:var(--text4);">기본 제공</p>
+                </div>
+              </div>
+              <p class="text-ui-sm" style="color:var(--text3);">6개</p>
+              <div class="flex items-center gap-1 justify-start sm:justify-end">
+                <button class="btn-ghost">수정</button>
+                <button class="btn-ghost" style="color:var(--text4);cursor:not-allowed;" disabled>고정</button>
+              </div>
+            </div>
+            <div class="category-table-row">
+              <div class="flex items-center gap-2 min-w-0">
+                <span class="category-dot default"></span>
+                <div class="min-w-0">
+                  <p class="text-ui-sm font-semibold line-clamp-1" style="color:var(--text1);">기본</p>
+                  <p class="text-ui-xs" style="color:var(--text4);">기본 제공</p>
+                </div>
+              </div>
+              <p class="text-ui-sm" style="color:var(--text3);">28개</p>
+              <div class="flex items-center gap-1 justify-start sm:justify-end">
+                <button class="btn-ghost">수정</button>
+                <button class="btn-ghost" style="color:var(--text4);cursor:not-allowed;" disabled>고정</button>
+              </div>
+            </div>
+            <div class="category-table-row">
+              <div class="flex items-center gap-2 min-w-0">
+                <span class="category-dot uncategorized"></span>
+                <div class="min-w-0">
+                  <p class="text-ui-sm font-semibold line-clamp-1" style="color:var(--text1);">미분류</p>
+                  <p class="text-ui-xs" style="color:var(--text4);">기본 제공</p>
+                </div>
+              </div>
+              <p class="text-ui-sm" style="color:var(--text3);">8개</p>
+              <div class="flex items-center gap-1 justify-start sm:justify-end">
+                <button class="btn-ghost">수정</button>
+                <button class="btn-ghost" style="color:var(--text4);cursor:not-allowed;" disabled>고정</button>
+              </div>
+            </div>
+            <div class="category-table-row">
+              <div class="flex items-center gap-2 min-w-0">
+                <span class="category-dot custom"></span>
+                <div class="min-w-0">
+                  <p class="text-ui-sm font-semibold line-clamp-1" style="color:var(--text1);">다이어그램</p>
+                  <p class="text-ui-xs" style="color:var(--text4);">사용자 추가</p>
+                </div>
+              </div>
+              <p class="text-ui-sm" style="color:var(--text3);">0개</p>
+              <div class="flex items-center gap-1 justify-start sm:justify-end">
+                <button class="btn-ghost">수정</button>
+                <button class="btn-ghost" style="color:var(--negative1);">삭제</button>
+              </div>
+            </div>
+          </div>
+          <div class="flex justify-end mt-5">
+            <button class="btn-secondary" onclick="closeModal('categoryModal')">닫기</button>
           </div>
         </div>
       </div>
@@ -942,11 +1239,16 @@
         openModal('assetModal');
       }
     }
+    function setCategoryFilter(button){
+      document.querySelectorAll('.category-chip.active').forEach(chip=>chip.classList.remove('active'));
+      button.classList.add('active');
+    }
 
     document.addEventListener('keydown',e=>{
       if(e.key==='Escape'&&document.getElementById('sidebar').classList.contains('mobile-open'))closeMobileSidebar();
       if(e.key==='Escape'&&selectionMode){toggleSelectionMode();return;}
       if(e.key==='Escape'&&document.getElementById('assetModal').classList.contains('open'))closeModal('assetModal');
+      if(e.key==='Escape'&&document.getElementById('categoryModal').classList.contains('open'))closeModal('categoryModal');
       // Arrow key navigation in detail modal
       if(document.getElementById('assetModal').classList.contains('open')){
         if(e.key==='ArrowLeft')navigateAsset(-1);

--- a/docs/client/designs/admin/admin-thumbnail-asset-picker.html
+++ b/docs/client/designs/admin/admin-thumbnail-asset-picker.html
@@ -1,0 +1,428 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>pyosh blog Admin - 썸네일 에셋 선택</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Gothic+A1:wght@300;400;500;600;700;800;900&display=swap">
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;500;600;700;800;900&display=swap">
+  <script src="https://code.iconify.design/iconify-icon/2.3.0/iconify-icon.min.js"></script>
+  <script>
+    tailwind.config = {
+      theme: {
+        extend: {
+          fontFamily: {
+            sans: ['Gothic A1', 'ui-sans-serif', 'system-ui', 'sans-serif'],
+          },
+          colors: {
+            bg: { 1: 'var(--background1)', 2: 'var(--background2)', 3: 'var(--background3)', 4: 'var(--background4)' },
+            tx: { 1: 'var(--text1)', 2: 'var(--text2)', 3: 'var(--text3)', 4: 'var(--text4)' },
+            bd: { 1: 'var(--border1)', 2: 'var(--border2)', 3: 'var(--border3)', 4: 'var(--border4)' },
+            primary: { 1: 'var(--primary1)', 2: 'var(--primary2)' },
+            positive: { 1: 'var(--positive1)', 2: 'var(--positive2)' },
+            negative: { 1: 'var(--negative1)', 2: 'var(--negative2)' },
+            grey: { 1: 'var(--grey1)', 2: 'var(--grey2)', 3: 'var(--grey3)', 4: 'var(--grey4)' },
+            yellow: { 1: 'var(--yellow1)', 2: 'var(--yellow2)' },
+          },
+        },
+      },
+    }
+  </script>
+  <style>
+    :root {
+      --dark-background1:#131415;--dark-background2:#1d1e20;--dark-background3:#26282a;--dark-background4:#303335;
+      --dark-text1:#e9eaeb;--dark-text2:#c4c6c9;--dark-text3:#a8adb1;--dark-text4:#919799;
+      --dark-border1:#a6abb0;--dark-border2:#a1a5aa;--dark-border3:#54595d;--dark-border4:#3e4245;
+      --dark-primary1:#a591e8;--dark-primary2:#c7bbf0;--dark-positive1:#10c67d;--dark-positive2:#78e2b8;
+      --dark-negative1:#f15966;--dark-negative2:#feccd0;--dark-grey1:#484c50;--dark-grey2:#797f85;--dark-grey3:#aeb2b6;--dark-grey4:#dee0e1;
+      --dark-yellow1:#ffbb32;--dark-yellow2:#ffd470;
+      --light-background1:#f9f9fa;--light-background2:#f1f2f3;--light-background3:#e6e8e9;--light-background4:#dbdde0;
+      --light-text1:#232629;--light-text2:#4b5158;--light-text3:#6b7780;--light-text4:#a3aab1;
+      --light-border1:#33383c;--light-border2:#a6adb3;--light-border3:#dbdde0;--light-border4:#eaebed;
+      --light-primary1:#8a6fe0;--light-primary2:#b09ee9;--light-positive1:#078556;--light-positive2:#41d69b;
+      --light-negative1:#e21223;--light-negative2:#f15966;--light-grey1:#f1f2f3;--light-grey2:#c7ccd0;--light-grey3:#9099a1;--light-grey4:#596068;
+      --light-yellow1:#f2a116;--light-yellow2:#ffbe3d;
+    }
+    body{
+      --background1:var(--light-background1);--background2:var(--light-background2);--background3:var(--light-background3);--background4:var(--light-background4);
+      --text1:var(--light-text1);--text2:var(--light-text2);--text3:var(--light-text3);--text4:var(--light-text4);
+      --border1:var(--light-border1);--border2:var(--light-border2);--border3:var(--light-border3);--border4:var(--light-border4);
+      --primary1:var(--light-primary1);--primary2:var(--light-primary2);--positive1:var(--light-positive1);--positive2:var(--light-positive2);
+      --negative1:var(--light-negative1);--negative2:var(--light-negative2);--grey1:var(--light-grey1);--grey2:var(--light-grey2);--grey3:var(--light-grey3);--grey4:var(--light-grey4);
+      --yellow1:var(--light-yellow1);--yellow2:var(--light-yellow2);
+      color:var(--text1);background:var(--background1);
+    }
+    body[data-theme="dark"]{
+      --background1:var(--dark-background1);--background2:var(--dark-background2);--background3:var(--dark-background3);--background4:var(--dark-background4);
+      --text1:var(--dark-text1);--text2:var(--dark-text2);--text3:var(--dark-text3);--text4:var(--dark-text4);
+      --border1:var(--dark-border1);--border2:var(--dark-border2);--border3:var(--dark-border3);--border4:var(--dark-border4);
+      --primary1:var(--dark-primary1);--primary2:var(--dark-primary2);--positive1:var(--dark-positive1);--positive2:var(--dark-positive2);
+      --negative1:var(--dark-negative1);--negative2:var(--dark-negative2);--grey1:var(--dark-grey1);--grey2:var(--dark-grey2);--grey3:var(--dark-grey3);--grey4:var(--dark-grey4);
+      --yellow1:var(--dark-yellow1);--yellow2:var(--dark-yellow2);
+    }
+    @media(prefers-color-scheme:dark){body:not([data-theme="light"]){
+      --background1:var(--dark-background1);--background2:var(--dark-background2);--background3:var(--dark-background3);--background4:var(--dark-background4);
+      --text1:var(--dark-text1);--text2:var(--dark-text2);--text3:var(--dark-text3);--text4:var(--dark-text4);
+      --border1:var(--dark-border1);--border2:var(--dark-border2);--border3:var(--dark-border3);--border4:var(--dark-border4);
+      --primary1:var(--dark-primary1);--primary2:var(--dark-primary2);--positive1:var(--dark-positive1);--positive2:var(--dark-positive2);
+      --negative1:var(--dark-negative1);--negative2:var(--dark-negative2);--grey1:var(--dark-grey1);--grey2:var(--dark-grey2);--grey3:var(--dark-grey3);--grey4:var(--dark-grey4);
+      --yellow1:var(--dark-yellow1);--yellow2:var(--dark-yellow2);
+    }}
+    body::after{content:'';position:fixed;inset:0;z-index:60;pointer-events:none;opacity:.025;
+      background-image:url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E");
+      background-repeat:repeat;background-size:256px 256px;}
+    ::-webkit-scrollbar{width:6px;height:6px}
+    ::-webkit-scrollbar-track{background:var(--background2)}
+    ::-webkit-scrollbar-thumb{background:var(--border3);border-radius:3px}
+    .line-clamp-1{display:-webkit-box;-webkit-line-clamp:1;-webkit-box-orient:vertical;overflow:hidden}
+    .admin-sidebar{
+      position:fixed;left:0;top:0;bottom:0;z-index:10;width:240px;
+      background:var(--background2);border-right:1px solid var(--border3);
+    }
+    .admin-content{margin-left:240px;min-height:100dvh;}
+    .admin-topbar{
+      position:sticky;top:0;z-index:8;height:56px;display:flex;align-items:center;gap:16px;padding:0 24px;
+      background:rgba(249,249,250,.82);backdrop-filter:blur(16px);border-bottom:1px solid var(--border4);
+    }
+    body[data-theme="dark"] .admin-topbar{background:rgba(19,20,21,.86);}
+    @media(prefers-color-scheme:dark){body:not([data-theme="light"]) .admin-topbar{background:rgba(19,20,21,.86);}}
+    .admin-nav-item{display:flex;align-items:center;gap:10px;padding:8px 12px;border-radius:8px;font-size:14px;color:var(--text2);}
+    .admin-nav-item.active{background:rgba(138,111,224,.1);color:var(--primary1);font-weight:600;}
+    .btn-primary{
+      display:inline-flex;align-items:center;justify-content:center;gap:6px;height:40px;padding:0 16px;
+      border-radius:12px;background:var(--primary1);color:white;font-size:14px;font-weight:700;transition:opacity .15s;
+    }
+    .btn-primary:hover{opacity:.9}.btn-primary:disabled{opacity:.55;cursor:not-allowed}
+    .btn-secondary{
+      display:inline-flex;align-items:center;justify-content:center;gap:6px;height:40px;padding:0 14px;
+      border-radius:12px;border:1px solid var(--border3);color:var(--text2);font-size:14px;font-weight:500;transition:border-color .15s,color .15s,background .15s;
+    }
+    .btn-secondary:hover{border-color:var(--border2);color:var(--text1);background:var(--background2)}
+    .input{
+      width:100%;height:40px;border-radius:12px;border:1px solid var(--border3);background:var(--background1);
+      color:var(--text1);font-size:13px;padding:0 12px;outline:none;transition:border-color .15s,box-shadow .15s;
+    }
+    .input:focus{border-color:var(--primary1);box-shadow:0 0 0 3px rgba(138,111,224,.12)}
+    .select{
+      width:100%;height:40px;border-radius:12px;border:1px solid var(--border3);background:var(--background1);
+      color:var(--text1);font-size:13px;padding:0 34px 0 12px;outline:none;appearance:none;
+      background-image:url("data:image/svg+xml,%3Csvg width='12' height='8' viewBox='0 0 12 8' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M1 1.5L6 6.5L11 1.5' stroke='%23838c95' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
+      background-repeat:no-repeat;background-position:right 12px center;
+    }
+    .editor-shell{
+      min-height:calc(100dvh - 56px);padding:24px;background:var(--background1);
+    }
+    .editor-frame{
+      height:calc(100dvh - 104px);min-height:620px;overflow:hidden;border:1px solid var(--border3);
+      border-radius:18px;background:var(--background1);box-shadow:0 16px 42px rgba(0,0,0,.06);
+    }
+    .editor-title-input{
+      width:100%;border:0;background:transparent;color:var(--text1);font-size:30px;line-height:38px;font-weight:700;outline:none;
+    }
+    .meta-pill{display:inline-flex;align-items:center;gap:8px;height:40px;border-radius:12px;border:1px solid var(--border3);background:var(--background1);padding:0 10px;color:var(--text2);font-size:13px;}
+    .modal-overlay{
+      position:fixed;inset:0;z-index:50;display:flex;align-items:center;justify-content:center;
+      padding:24px;background:rgba(90,95,103,.5);
+    }
+    .asset-modal{
+      width:min(94vw,72rem);height:min(88vh,56rem);display:flex;flex-direction:column;overflow:hidden;
+      border-radius:24px;background:var(--background1);box-shadow:0 24px 80px rgba(0,0,0,.24);text-align:left;
+    }
+    .category-chip{
+      display:inline-flex;align-items:center;gap:6px;height:34px;padding:0 12px;border-radius:999px;
+      border:1px solid var(--border4);background:var(--background1);color:var(--text2);font-size:13px;font-weight:600;transition:background .15s,border-color .15s,color .15s;
+    }
+    .category-chip:hover{background:var(--background3);border-color:var(--border3)}
+    .category-chip.active{background:rgba(138,111,224,.12);border-color:rgba(138,111,224,.36);color:var(--primary1)}
+    .category-count{font-family:'Outfit','Gothic A1',sans-serif;font-size:12px;color:var(--text4)}
+    .category-chip.active .category-count{color:var(--primary1)}
+    .dot{width:8px;height:8px;border-radius:50%;background:var(--grey3)}
+    .dot.thumbnail{background:var(--primary1)}.dot.default{background:var(--positive1)}.dot.uncategorized{background:var(--grey3)}
+    .asset-card{
+      overflow:hidden;border-radius:20px;border:1px solid var(--border3);background:var(--background2);
+      text-align:left;transition:border-color .15s,box-shadow .15s,transform .15s;
+    }
+    .asset-card:hover{border-color:var(--border2)}
+    .asset-card.selected{border-color:var(--primary1);box-shadow:0 0 0 3px rgba(138,111,224,.12)}
+    .asset-card:active{transform:scale(.99)}
+    .asset-media{position:relative;aspect-ratio:4/3;background:var(--background3);overflow:hidden}
+    .asset-media img{width:100%;height:100%;object-fit:cover}
+    .selected-pill{
+      position:absolute;left:12px;top:12px;min-width:32px;min-height:32px;display:inline-flex;align-items:center;justify-content:center;
+      border-radius:999px;border:1px solid var(--border3);background:rgba(249,249,250,.88);backdrop-filter:blur(12px);
+      color:var(--text3);font-size:12px;font-weight:700;
+    }
+    .asset-card.selected .selected-pill{background:var(--primary1);border-color:var(--primary1);color:#fff;padding:0 10px}
+    .badge{
+      display:inline-flex;align-items:center;gap:5px;border-radius:999px;padding:4px 8px;font-size:11px;font-weight:700;
+      background:var(--background3);color:var(--text3);white-space:nowrap;
+    }
+    .badge.thumbnail{background:rgba(138,111,224,.12);color:var(--primary1)}
+    .badge.default{background:rgba(7,133,86,.1);color:var(--positive1)}
+    .badge.uncategorized{background:rgba(144,153,161,.12);color:var(--grey4)}
+    .summary-card{border:1px solid var(--border4);border-radius:16px;background:var(--background2);padding:12px}
+    @media(max-width:767px){
+      .admin-sidebar{display:none}.admin-content{margin-left:0}.editor-shell{padding:12px}.editor-frame{height:auto;min-height:760px}
+      .modal-overlay{padding:0;align-items:stretch}.asset-modal{width:100vw;height:100dvh;border-radius:0}
+    }
+  </style>
+</head>
+<body class="min-h-[100dvh] antialiased">
+  <aside class="admin-sidebar p-3" aria-label="관리자 메뉴">
+    <div class="flex h-11 items-center gap-2 px-1" style="border-bottom:1px solid var(--border4);">
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" class="h-7 w-7 shrink-0" style="fill:var(--primary1)"><path d="M128,26.25C71.81,26.25,26.25,71.8,26.25,128c0,32.76,15.49,61.9,39.53,80.51c14.84-24.7,29.68-49.4,44.53-74.1c-18.12-15.67-30.87-37.86-40.59-60.59c-1.79-4.18,2.26-13.74,6.37-16.22c3.5-2.11,5.62,3.36,7.56,7.59c8.92,19.45,19.83,40.08,35.26,54.47l31.97-54.8c1.8-3.09,4.75-4.55,7.69-4.24c1.69,0.12,3.21,0.55,4.92,1.65c14.53,9.41,25.4,24.78,29.28,42.43c3.51,15.99,2.05,34.39-11.95,44.16c-13.72,9.57-32.44,6.65-46.86,0.48c-2.94-1.26-5.76-2.66-8.49-4.21c-0.01,0.01-33.12,55.64-43.75,73.49c13.89,7.11,29.62,11.12,46.3,11.12c56.19,0,101.75-45.56,101.75-101.75C229.75,71.8,184.19,26.25,128,26.25z"/></svg>
+      <span class="rounded px-1.5 py-0.5 text-xs font-semibold" style="background:rgba(138,111,224,.12);color:var(--primary1);">Admin</span>
+    </div>
+    <nav class="mt-4 flex flex-col gap-1">
+      <a class="admin-nav-item"><iconify-icon icon="solar:chart-2-linear" width="20"></iconify-icon>대시보드</a>
+      <a class="admin-nav-item active"><iconify-icon icon="solar:pen-new-round-linear" width="20"></iconify-icon>글 작성</a>
+      <a class="admin-nav-item"><iconify-icon icon="solar:folder-open-linear" width="20"></iconify-icon>카테고리</a>
+      <a class="admin-nav-item"><iconify-icon icon="solar:gallery-wide-linear" width="20"></iconify-icon>에셋</a>
+    </nav>
+  </aside>
+
+  <div class="admin-content">
+    <header class="admin-topbar">
+      <h1 class="text-lg font-bold" style="color:var(--text1);">새 글 작성</h1>
+      <div class="ml-auto flex items-center gap-2">
+        <span class="hidden text-sm sm:inline" style="color:var(--text3);">자동 저장됨</span>
+        <button class="btn-secondary" style="height:34px;padding:0 10px;font-size:12px;">미리보기</button>
+        <button class="btn-primary" style="height:34px;padding:0 12px;font-size:12px;">발행</button>
+      </div>
+    </header>
+
+    <main class="editor-shell">
+      <section class="editor-frame">
+        <div class="flex h-full flex-col">
+          <div class="border-b px-6 py-4" style="border-color:var(--border3);background:var(--background2);">
+            <input class="editor-title-input" value="React Server Components를 다시 읽기" aria-label="제목">
+            <div class="mt-4 flex flex-wrap items-center gap-3">
+              <span class="meta-pill"><span style="color:var(--text4);">카테고리</span> Frontend</span>
+              <span class="meta-pill"><span style="color:var(--text4);">태그</span> React, Next.js</span>
+              <span class="meta-pill">
+                <span style="color:var(--text4);">썸네일</span>
+                <button class="inline-flex h-8 w-8 items-center justify-center rounded-lg" style="border:1px solid var(--border3);background:var(--background1);color:var(--text2);" aria-label="에셋 갤러리">
+                  <iconify-icon icon="solar:gallery-wide-linear" width="14"></iconify-icon>
+                </button>
+                <span class="inline-flex h-9 w-12 items-center justify-center overflow-hidden rounded-lg" style="border:1px solid var(--border3);background:var(--background3);">
+                  <img src="https://picsum.photos/seed/react-lifecycle-diagram/96/72" alt="썸네일 미리보기" class="h-full w-full object-cover">
+                </span>
+              </span>
+              <span class="meta-pill">작성중</span>
+            </div>
+          </div>
+          <div class="grid min-h-0 flex-1 grid-cols-1 lg:grid-cols-2">
+            <div class="min-h-0 border-r p-6" style="border-color:var(--border3);">
+              <div class="mb-4 flex items-center gap-2">
+                <button class="btn-secondary" style="height:32px;padding:0 10px;font-size:12px;"><iconify-icon icon="solar:gallery-minimalistic-linear" width="15"></iconify-icon>이미지</button>
+                <button class="btn-secondary" style="height:32px;padding:0 10px;font-size:12px;">B</button>
+                <button class="btn-secondary" style="height:32px;padding:0 10px;font-size:12px;">I</button>
+              </div>
+              <div class="h-[calc(100%-3rem)] rounded-2xl p-5 font-mono text-sm leading-7" style="background:var(--background2);color:var(--text2);">
+                # React Server Components를 다시 읽기<br><br>
+                본문 이미지를 여러 장 넣어도 썸네일 선택 모달에서는 카테고리로 후보를 좁힐 수 있습니다.<br><br>
+                ![다이어그램](/uploads/2026/05/diagram.png)
+              </div>
+            </div>
+            <div class="min-h-0 p-6">
+              <div class="rounded-2xl border p-5" style="border-color:var(--border3);background:var(--background1);">
+                <p class="mb-3 text-xs font-semibold uppercase tracking-[.18em]" style="color:var(--text4);">미리보기</p>
+                <h2 class="text-2xl font-bold" style="color:var(--text1);">React Server Components를 다시 읽기</h2>
+                <p class="mt-3 text-sm leading-6" style="color:var(--text3);">본문 이미지를 여러 장 넣어도 썸네일 선택 모달에서는 카테고리로 후보를 좁힐 수 있습니다.</p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+    </main>
+  </div>
+
+  <div class="modal-overlay">
+    <section class="asset-modal" role="dialog" aria-modal="true" aria-label="에셋 선택">
+      <header class="border-b px-6 py-5" style="border-color:var(--border3);">
+        <div class="flex items-start justify-between gap-4">
+          <div>
+            <p class="text-xs uppercase tracking-[.2em]" style="color:var(--text4);">Asset picker</p>
+            <h2 class="mt-2 text-xl font-semibold" style="color:var(--text1);">에셋 선택</h2>
+            <p class="mt-1 text-sm" style="color:var(--text3);">썸네일로 사용할 이미지를 선택하세요.</p>
+          </div>
+          <button class="inline-flex h-10 w-10 items-center justify-center rounded-full text-xl" style="border:1px solid var(--border3);color:var(--text3);" aria-label="에셋 선택 닫기">×</button>
+        </div>
+
+        <div class="mt-5 grid gap-3 lg:grid-cols-[minmax(0,1fr)_15rem]">
+          <div class="flex flex-wrap items-center gap-2">
+            <button class="category-chip" type="button" onclick="setCategory(this)">전체 <span class="category-count">42</span></button>
+            <button class="category-chip active" type="button" onclick="setCategory(this)"><span class="dot thumbnail"></span>썸네일 <span class="category-count">6</span></button>
+            <button class="category-chip" type="button" onclick="setCategory(this)"><span class="dot default"></span>기본 <span class="category-count">28</span></button>
+            <button class="category-chip" type="button" onclick="setCategory(this)"><span class="dot uncategorized"></span>미분류 <span class="category-count">8</span></button>
+          </div>
+          <div class="summary-card flex items-center gap-3">
+            <img src="https://picsum.photos/seed/blog-thumbnail-rsc/96/72" alt="선택된 에셋" class="h-12 w-16 rounded-xl object-cover">
+            <div class="min-w-0">
+              <p class="line-clamp-1 text-sm font-semibold" style="color:var(--text1);">RSC 글 대표 썸네일</p>
+              <p class="line-clamp-1 text-xs" style="color:var(--text4);">blog-thumbnail-rsc.png</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="mt-3 grid gap-2 md:grid-cols-[minmax(0,1fr)_12rem_10rem]">
+          <label class="relative">
+            <iconify-icon icon="solar:magnifer-linear" width="16" style="position:absolute;left:12px;top:50%;transform:translateY(-50%);color:var(--text4);"></iconify-icon>
+            <input class="input" style="padding-left:36px;" placeholder="별명 또는 파일명 검색" value="">
+          </label>
+          <select class="select" aria-label="정렬">
+            <option>최근 업로드순</option>
+            <option>파일명순</option>
+            <option>용량순</option>
+          </select>
+          <label class="inline-flex h-10 items-center gap-2 rounded-xl px-3 text-sm" style="border:1px solid var(--border3);color:var(--text2);">
+            <input type="checkbox" checked style="accent-color:var(--primary1);">
+            현재 글 우선
+          </label>
+        </div>
+      </header>
+
+      <div class="min-h-0 flex-1 overflow-y-auto px-6 py-6">
+        <div class="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+          <button class="asset-card selected" type="button" onclick="selectAsset(this)">
+            <div class="asset-media">
+              <img src="https://picsum.photos/seed/blog-thumbnail-rsc/640/480" alt="RSC 글 대표 썸네일">
+              <span class="selected-pill">선택</span>
+            </div>
+            <div class="space-y-2 px-4 py-3">
+              <div class="flex items-start justify-between gap-2">
+                <div class="min-w-0">
+                  <p class="line-clamp-1 text-sm font-semibold" style="color:var(--text1);">RSC 글 대표 썸네일</p>
+                  <p class="line-clamp-1 text-xs" style="color:var(--text4);">blog-thumbnail-rsc.png</p>
+                </div>
+                <span class="badge thumbnail">썸네일</span>
+              </div>
+              <p class="text-xs" style="color:var(--text4);">0.7 MB · 800×450</p>
+            </div>
+          </button>
+
+          <button class="asset-card" type="button" onclick="selectAsset(this)">
+            <div class="asset-media">
+              <img src="https://picsum.photos/seed/react-lifecycle-diagram/640/480" alt="React 생명주기 대표 이미지">
+              <span class="selected-pill"></span>
+            </div>
+            <div class="space-y-2 px-4 py-3">
+              <div class="flex items-start justify-between gap-2">
+                <div class="min-w-0">
+                  <p class="line-clamp-1 text-sm font-semibold" style="color:var(--text1);">React 생명주기 대표 이미지</p>
+                  <p class="line-clamp-1 text-xs" style="color:var(--text4);">react-lifecycle-diagram.png</p>
+                </div>
+                <span class="badge thumbnail">썸네일</span>
+              </div>
+              <p class="text-xs" style="color:var(--text4);">3.2 MB · 1920×1080</p>
+            </div>
+          </button>
+
+          <button class="asset-card" type="button" onclick="selectAsset(this)">
+            <div class="asset-media">
+              <img src="https://picsum.photos/seed/post-cover-architecture/640/480" alt="아키텍처 글 커버">
+              <span class="selected-pill"></span>
+            </div>
+            <div class="space-y-2 px-4 py-3">
+              <div class="flex items-start justify-between gap-2">
+                <div class="min-w-0">
+                  <p class="line-clamp-1 text-sm font-semibold" style="color:var(--text1);">아키텍처 글 커버</p>
+                  <p class="line-clamp-1 text-xs" style="color:var(--text4);">post-cover-architecture.png</p>
+                </div>
+                <span class="badge thumbnail">썸네일</span>
+              </div>
+              <p class="text-xs" style="color:var(--text4);">1.4 MB · 1280×720</p>
+            </div>
+          </button>
+
+          <button class="asset-card" type="button" onclick="selectAsset(this)">
+            <div class="asset-media">
+              <img src="https://picsum.photos/seed/nextjs-routing-flow/640/480" alt="Next.js 라우팅 플로우">
+              <span class="selected-pill"></span>
+            </div>
+            <div class="space-y-2 px-4 py-3">
+              <div class="flex items-start justify-between gap-2">
+                <div class="min-w-0">
+                  <p class="line-clamp-1 text-sm font-semibold" style="color:var(--text1);">Next.js 라우팅 플로우</p>
+                  <p class="line-clamp-1 text-xs" style="color:var(--text4);">nextjs-routing-flow.png</p>
+                </div>
+                <span class="badge default">기본</span>
+              </div>
+              <p class="text-xs" style="color:var(--text4);">2.1 MB · 1600×900</p>
+            </div>
+          </button>
+
+          <button class="asset-card" type="button" onclick="selectAsset(this)">
+            <div class="asset-media">
+              <img src="https://picsum.photos/seed/css-grid-cheatsheet/640/480" alt="CSS Grid 요약표">
+              <span class="selected-pill"></span>
+            </div>
+            <div class="space-y-2 px-4 py-3">
+              <div class="flex items-start justify-between gap-2">
+                <div class="min-w-0">
+                  <p class="line-clamp-1 text-sm font-semibold" style="color:var(--text1);">CSS Grid 요약표</p>
+                  <p class="line-clamp-1 text-xs" style="color:var(--text4);">css-grid-cheatsheet.png</p>
+                </div>
+                <span class="badge default">기본</span>
+              </div>
+              <p class="text-xs" style="color:var(--text4);">4.5 MB · 2400×1350</p>
+            </div>
+          </button>
+
+          <button class="asset-card" type="button" onclick="selectAsset(this)">
+            <div class="asset-media">
+              <img src="https://picsum.photos/seed/api-response-example/640/480" alt="API 응답 예시">
+              <span class="selected-pill"></span>
+            </div>
+            <div class="space-y-2 px-4 py-3">
+              <div class="flex items-start justify-between gap-2">
+                <div class="min-w-0">
+                  <p class="line-clamp-1 text-sm font-semibold" style="color:var(--text1);">API 응답 예시</p>
+                  <p class="line-clamp-1 text-xs" style="color:var(--text4);">api-response-example.png</p>
+                </div>
+                <span class="badge uncategorized">미분류</span>
+              </div>
+              <p class="text-xs" style="color:var(--text4);">0.9 MB · 800×600</p>
+            </div>
+          </button>
+        </div>
+      </div>
+
+      <footer class="flex flex-col gap-4 border-t px-6 py-5 md:flex-row md:items-center md:justify-between" style="border-color:var(--border3);">
+        <div class="text-sm" style="color:var(--text4);">총 42개 중 1-18 · 썸네일 카테고리 우선 표시</div>
+        <div class="flex flex-wrap items-center justify-end gap-3">
+          <button class="btn-secondary" disabled style="opacity:.5;">이전</button>
+          <span class="text-sm" style="color:var(--text3);">1/3</span>
+          <button class="btn-secondary">다음</button>
+          <button class="btn-secondary">취소</button>
+          <button class="btn-primary">선택</button>
+        </div>
+      </footer>
+    </section>
+  </div>
+
+  <script>
+    function getPreferredTheme(){
+      const stored=localStorage.getItem('theme');
+      if(stored) return stored;
+      return window.matchMedia('(prefers-color-scheme:dark)').matches?'dark':'light';
+    }
+    document.body.setAttribute('data-theme',getPreferredTheme());
+    function setCategory(button){
+      document.querySelectorAll('.category-chip.active').forEach((chip)=>chip.classList.remove('active'));
+      button.classList.add('active');
+    }
+    function selectAsset(card){
+      document.querySelectorAll('.asset-card.selected').forEach((asset)=>{
+        asset.classList.remove('selected');
+        const pill=asset.querySelector('.selected-pill');
+        if(pill) pill.textContent='';
+      });
+      card.classList.add('selected');
+      const pill=card.querySelector('.selected-pill');
+      if(pill) pill.textContent='선택';
+    }
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add asset management wireframe coverage for asset categories and display names
- Add a dedicated thumbnail asset picker wireframe based on the current client modal flow
- Capture upload queue metadata, category filtering, detail editing, category management, and bulk category changes

## Related Issues
- pyo-sh/pyosh-blog-be#124
- pyo-sh/pyosh-blog-fe#381

## Validation
- `node` inline script syntax check for the updated HTML files
- `git diff --check -- docs/client/designs/admin/admin-asset.html docs/client/designs/admin/admin-thumbnail-asset-picker.html`
