### PR TITLE
chore: sync tmux session layouts

### DIFF
--- a/tools/ARCHITECTURE.md
+++ b/tools/ARCHITECTURE.md
@@ -151,8 +151,9 @@ The host can run an outer `blog` session, then attach to the inner Docker `lab` 
 
 ```text
 blog
-├─ work       2 panes
-└─ project    attaches to dev-lab:lab
+├─ lab        2 panes (first pane attaches to dev-lab:lab)
+├─ server1    2 panes
+└─ client1    2 panes
 
 lab
 ├─ lab        2 panes

--- a/tools/tmux/README.md
+++ b/tools/tmux/README.md
@@ -78,8 +78,9 @@ tmuxinator start -p tools/tmux/session.docker.yml
 
 | Window | 이름 | Layout | Panes | 용도 |
 |--------|------|--------|-------|------|
-| 0 | work | even-horizontal | 2 | 메인 작업 |
-| 1 | project | - | 1 | 프로젝트 관리 |
+| 0 | lab | even-horizontal | 2 | 메인 작업 |
+| 1 | server1 | even-horizontal | 2 | 서버 작업 |
+| 2 | client1 | even-horizontal | 2 | 클라이언트 작업 |
 
 #### Docker 세션 (`lab`)
 

--- a/tools/tmux/session.docker.yml
+++ b/tools/tmux/session.docker.yml
@@ -14,6 +14,7 @@
 name: lab
 root: <%= ENV.fetch('TMUX_ROOT', '.') %>
 
+# Keep window names and pane counts mirrored with session.host.yml.
 windows:
   - lab:
       layout: even-horizontal

--- a/tools/tmux/session.host.wait-and-attach.sh
+++ b/tools/tmux/session.host.wait-and-attach.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Start the tmuxinator session, then replace the project pane's process
+# Start the tmuxinator session, then replace the first lab pane's process
 # with docker attach — bypassing zsh send-keys race condition.
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
@@ -9,7 +9,7 @@ tmuxinator start -p "$SCRIPT_DIR/session.host.yml" --no-attach
 
 # respawn-pane -k: kill the pane's shell and replace it with this command directly.
 # This runs the wait-loop as the pane's process (no zsh involved).
-tmux respawn-pane -k -t blog:project "
+tmux respawn-pane -k -t blog:lab.0 "
   while ! docker exec dev-lab tmux has-session -t lab 2>/dev/null; do
     sleep 0.2
   done

--- a/tools/tmux/session.host.yml
+++ b/tools/tmux/session.host.yml
@@ -14,13 +14,22 @@
 name: blog
 root: <%= ENV.fetch('TMUX_ROOT', '.') %>
 
+# Keep window names and pane counts mirrored with session.docker.yml.
 windows:
-  - work:
+  - lab:
       layout: even-horizontal
       panes:
         - # left
         - # right
 
-  - project:
+  - server1:
+      layout: even-horizontal
       panes:
-        - # auto-attached by session.host.wait-and-attach.sh
+        - # left
+        - # right
+
+  - client1:
+      layout: even-horizontal
+      panes:
+        - # left
+        - # right


### PR DESCRIPTION
## PR 제목

chore: sync tmux session layouts

## Summary

Closes: N/A

Sync the host tmuxinator session layout with the Docker tmux session layout so both define the same windows and pane counts.

## Changes

| File | Change |
|------|--------|
| `tools/tmux/session.host.yml` | Mirror Docker session windows: `lab`, `server1`, `client1`, each with 2 panes |
| `tools/tmux/session.docker.yml` | Document that window names and pane counts are mirrored with host config |
| `tools/tmux/session.host.wait-and-attach.sh` | Update auto-attach target from removed `project` window to `blog:lab.0` |
| `tools/tmux/README.md` | Update Host session table to match the synchronized layout |
| `tools/ARCHITECTURE.md` | Update tmux layer diagram for the new Host session layout |

## Type

- [ ] feat — New feature
- [ ] fix — Bug fix
- [ ] refactor — Code restructuring (no behavior change)
- [ ] docs — Documentation only
- [ ] test — Test additions or updates
- [x] chore — Build, CI, or tooling changes

## Checklist

### 작성자 확인 (Author)

- [x] 코드가 정상 동작하는 것을 로컬에서 확인했습니다
- [x] 관련 테스트를 추가하거나 수정했습니다
- [x] 불필요한 console.log / 디버깅 코드를 제거했습니다

### Reviewer

- [ ] Changes match the PR description
- [ ] Edge cases are handled appropriately
- [ ] No security issues found

## Notes

Validated with:

- `tmuxinator debug -p tools/tmux/session.host.yml`
- `tmuxinator debug -p tools/tmux/session.docker.yml`
- `bash -n tools/tmux/session.host.wait-and-attach.sh`
- `git diff --check`
