### PR TITLE
fix: restore tmux host project layout

### DIFF
--- a/tools/ARCHITECTURE.md
+++ b/tools/ARCHITECTURE.md
@@ -151,9 +151,8 @@ The host can run an outer `blog` session, then attach to the inner Docker `lab` 
 
 ```text
 blog
-├─ lab        2 panes (first pane attaches to dev-lab:lab)
-├─ server1    2 panes
-└─ client1    2 panes
+├─ work       2 panes
+└─ project    3 panes (top attaches to dev-lab:lab)
 
 lab
 ├─ lab        2 panes

--- a/tools/tmux/README.md
+++ b/tools/tmux/README.md
@@ -78,9 +78,8 @@ tmuxinator start -p tools/tmux/session.docker.yml
 
 | Window | 이름 | Layout | Panes | 용도 |
 |--------|------|--------|-------|------|
-| 0 | lab | even-horizontal | 2 | 메인 작업 |
-| 1 | server1 | even-horizontal | 2 | 서버 작업 |
-| 2 | client1 | even-horizontal | 2 | 클라이언트 작업 |
+| 0 | work | even-horizontal | 2 | 메인 작업 |
+| 1 | project | main-horizontal | 3 | 프로젝트 관리 |
 
 #### Docker 세션 (`lab`)
 

--- a/tools/tmux/session.host.wait-and-attach.sh
+++ b/tools/tmux/session.host.wait-and-attach.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Start the tmuxinator session, then replace the first lab pane's process
+# Start the tmuxinator session, then replace the project pane's process
 # with docker attach — bypassing zsh send-keys race condition.
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
@@ -9,7 +9,7 @@ tmuxinator start -p "$SCRIPT_DIR/session.host.yml" --no-attach
 
 # respawn-pane -k: kill the pane's shell and replace it with this command directly.
 # This runs the wait-loop as the pane's process (no zsh involved).
-tmux respawn-pane -k -t blog:lab.0 "
+tmux respawn-pane -k -t blog:project "
   while ! docker exec dev-lab tmux has-session -t lab 2>/dev/null; do
     sleep 0.2
   done

--- a/tools/tmux/session.host.yml
+++ b/tools/tmux/session.host.yml
@@ -14,9 +14,8 @@
 name: blog
 root: <%= ENV.fetch('TMUX_ROOT', '.') %>
 
-# Keep the host and docker session window names aligned.
 windows:
-  - lab:
+  - work:
       layout: even-horizontal
       panes:
         - # left
@@ -25,6 +24,6 @@ windows:
   - project:
       layout: main-horizontal
       panes:
-        - ./tools/tmux/session.host.wait-and-attach.sh
+        - # auto-attached by session.host.wait-and-attach.sh
         - # bottom left
         - # bottom right


### PR DESCRIPTION
## Summary
- restore the host tmux `project` window attach target to a non-recursive pane
- add two lower panes to the host `project` window using `main-horizontal`
- align tmux docs with the restored host layout

## Testing
- not run
